### PR TITLE
Correção da rota do autocomplete de produto para apontar para a rota correta

### DIFF
--- a/application/views/vendas/editarVenda.php
+++ b/application/views/vendas/editarVenda.php
@@ -278,7 +278,7 @@ $(document).ready(function(){
      });
 
      $("#produto").autocomplete({
-            source: "<?php echo base_url(); ?>index.php/os/autoCompleteProdutoSaida",
+            source: "<?php echo base_url(); ?>index.php/os/autoCompleteProduto",
             minLength: 2,
             select: function( event, ui ) {
 


### PR DESCRIPTION
Correção da rota do autocomplete de produto para apontar para a rota correta.

Não estavam aparecendo os produtos no autocomplete.