### PR TITLE
Correção na hash da senha padrão do admin

### DIFF
--- a/banco.sql
+++ b/banco.sql
@@ -491,7 +491,7 @@ INSERT INTO `permissoes` (`idPermissao`, `nome`, `permissoes`, `situacao`, `data
 
 
 INSERT INTO `usuarios` (`idUsuarios`, `nome`, `rg`, `cpf`, `rua`, `numero`, `bairro`, `cidade`, `estado`, `email`, `senha`, `telefone`, `celular`, `situacao`, `dataCadastro`, `permissoes_id`) VALUES
-(1, 'admin', 'MG-25.502.560', '600.021.520-87', 'Rua Acima', '12', 'Alvorada', 'Teste', 'MG', 'admin@admin.com', '$2y$10$1mCFKeikJwoLXaTVsfZIxOUGOtw8gQhhD24NmEBTMkxoaL2GSzlnm', '0000-0000', '', 1, '2013-11-22', 1);
+(1, 'admin', 'MG-25.502.560', '600.021.520-87', 'Rua Acima', '12', 'Alvorada', 'Teste', 'MG', 'admin@admin.com', '$2y$10$lAW0AXb0JLZxR0yDdfcBcu3BN9c2AXKKjKTdug7Or0pr6cSGtgyGO', '0000-0000', '', 1, '2013-11-22', 1);
 
 
 


### PR DESCRIPTION
Correção na hash da senha padrão do admin onde a mesma estava como 'teste' ao invés de '123456'.

connect to #130 