### PR TITLE
Adequação para exibir o nome do anexo embaixo do thumbnail

### DIFF
--- a/application/views/conecte/detalhes_os.php
+++ b/application/views/conecte/detalhes_os.php
@@ -199,7 +199,7 @@
                                             echo '<div style="margin-left: 0" class="span3"><a href="#modal-anexo" imagem="'.$a->idAnexos.'" link="'.$link.'" role="button" class="btn anexo" data-toggle="modal"><img src="'.$thumb.'" alt=""></a></div>';
                                             $flag += 4;
                                         } else {
-                                            echo '<div class="span3"><a href="#modal-anexo" imagem="'.$a->idAnexos.'" link="'.$link.'" role="button" class="btn anexo" data-toggle="modal"><img src="'.$thumb.'" alt=""></a></div>';
+                                            echo '<div class="span3"><a href="#modal-anexo" imagem="'.$a->idAnexos.'" link="'.$link.'" role="button" class="btn anexo" data-toggle="modal"><img src="'.$thumb.'" alt=""><p align="center">'. $a->anexo .'</p></a></div>';
                                         }
                                         $cont ++;
                                     } ?>

--- a/application/views/os/editarOs.php
+++ b/application/views/os/editarOs.php
@@ -266,7 +266,7 @@
                                             echo '<div style="margin-left: 0" class="span3"><a href="#modal-anexo" imagem="'.$a->idAnexos.'" link="'.$link.'" role="button" class="btn anexo" data-toggle="modal"><img src="'.$thumb.'" alt=""></a></div>';
                                             $flag += 4;
                                         } else {
-                                            echo '<div class="span3"><a href="#modal-anexo" imagem="'.$a->idAnexos.'" link="'.$link.'" role="button" class="btn anexo" data-toggle="modal"><img src="'.$thumb.'" alt=""></a></div>';
+                                            echo '<div class="span3"><a href="#modal-anexo" imagem="'.$a->idAnexos.'" link="'.$link.'" role="button" class="btn anexo" data-toggle="modal"><img src="'.$thumb.'" alt=""><p align="center">'. $a->anexo .'</p></a></div>';
                                         }
                                         $cont ++;
                                     } ?>


### PR DESCRIPTION
connect to #169 

Adequação para exibir o nome do anexo embaixo do thumbnail conforme imagem abaixo.

![image](https://user-images.githubusercontent.com/13210429/43617975-0c3608b6-969c-11e8-8ab1-f9d408f0755f.png)
