### PR TITLE
Ajuste data por extenso no topo do tema.

### DIFF
--- a/application/views/tema/topo.php
+++ b/application/views/tema/topo.php
@@ -74,7 +74,7 @@
           setlocale(LC_TIME, 'pt_BR', 'pt_BR.utf-8', 'pt_BR.utf-8', 'portuguese');
           date_default_timezone_set('America/Sao_Paulo');
           $uppercaseMonth = ucfirst(gmstrftime('%B'));
-          echo ucfirst(strftime('%A, %d de ' . $uppercaseMonth . ' de %Y', strtotime('today')));
+          echo utf8_encode(ucfirst(strftime( '%A, %d de ' .$uppercaseMonth. ' de %Y', strtotime('today'))));
           ?>
           <i class="far fa-clock"></i></i> <span id="timer"></span></span></li>
     </ul>


### PR DESCRIPTION
Inclui o utf8_encode, para prevenir que os dias por extenso não apareçam com caracteres estranhos, por exemplo: ter**Ç**a-feira, que aparecia com um simbolo de interrogação.