### PR TITLE
Status faturado no filtro de relatório de OS

### DIFF
--- a/application/views/relatorios/rel_os.php
+++ b/application/views/relatorios/rel_os.php
@@ -57,6 +57,7 @@
                                     <option value="Aberto">Aberto</option>
                                     <option value="Em Andamento">Em Andamento</option>
                                     <option value="Finalizado">Finalizado</option>
+                                    <option value="Faturado">Faturado</option>
                                     <option value="Cancelado">Cancelado</option>
                                     <option value="Aguardando Peças">Aguardando Peças</option>
                                 </select>


### PR DESCRIPTION
Incluí o status "Faturado" no relatório de OS, o mesmo não havia.