### PR TITLE
Bug Fix - Issue #513

### DIFF
--- a/application/controllers/Mine.php
+++ b/application/controllers/Mine.php
@@ -46,9 +46,11 @@ class Mine extends CI_Controller
             $this->db->where('email', $email);
             $this->db->where('documento', $documento);
             $this->db->limit(1);
-            $cliente = $this->db->get('clientes')->row();
-
-            if (count($cliente) > 0) {
+            // Bugfix - Issue #513 - @giovanne-oliveira
+            //if (count($cliente) > 0) {
+            $cliente = $this->db->get('clientes');
+            if($cliente->num_rows() > 0){
+                $cliente = $cliente->row();
                 $dados = array('nome' => $cliente->nomeCliente, 'cliente_id' => $cliente->idClientes, 'conectado' => true);
                 $this->session->set_userdata($dados);
 

--- a/application/views/conecte/login.php
+++ b/application/views/conecte/login.php
@@ -128,7 +128,7 @@
                             if (data.result == true) {
                                 window.location.href = "<?php echo base_url(); ?>index.php/mine/painel";
                             } else {
-                                $('#call-modal').trigger('click');
+                                $("#notification").modal();
                             }
                         }
                     });


### PR DESCRIPTION
Issue #513 - Bug in Client Area, logic change in php count() function. Now mapos first check if query num_rows(), and only if it is greater than 0, it fetches the result into an object.