### PR TITLE
Trocar attr por prop na lancamentos.php

### DIFF
--- a/application/views/financeiro/lancamentos.php
+++ b/application/views/financeiro/lancamentos.php
@@ -527,10 +527,10 @@ $periodo = $this->input->get('periodo');
       $("#urlAtualEditar").val($(location).attr('href'));
       var baixado = $(this).attr('baixado');
       if (baixado == 1) {
-        $("#pagoEditar").attr('checked', true);
+        $("#pagoEditar").prop('checked', true);
         $("#divPagamentoEditar").show();
       } else {
-        $("#pagoEditar").attr('checked', false);
+        $("#pagoEditar").prop('checked', false);
         $("#divPagamentoEditar").hide();
       }
 


### PR DESCRIPTION
Na lancamentos.php o uso de attr ao invés de prop na linha 530 e 533, não permite o checkbox "pagoEditar" manter o estado, após trocar para prop o problema foi corrigido.

Como reproduzir o erro:

1 - Na Financeiro > Lançamentos, abra um lançamento PAGO clicando em editar
2 - abra um lançamento NÃO PAGO (ex: PENDENTE) clicando em editar
3 - abra novamente um lançamento PAGO, e verá que o checkbox está desmarcado