### PR TITLE
Consertando erro ao atualizar versão

### DIFF
--- a/application/views/financeiro/lancamentos.php
+++ b/application/views/financeiro/lancamentos.php
@@ -527,10 +527,10 @@ $periodo = $this->input->get('periodo');
       $("#urlAtualEditar").val($(location).attr('href'));
       var baixado = $(this).attr('baixado');
       if (baixado == 1) {
-        $("#pagoEditar").attr('checked', true);
+        $("#pagoEditar").prop('checked', true);
         $("#divPagamentoEditar").show();
       } else {
-        $("#pagoEditar").attr('checked', false);
+        $("#pagoEditar").prop('checked', false);
         $("#divPagamentoEditar").hide();
       }
 


### PR DESCRIPTION
Consegui atualizar a versão do Mapos mudando o arquivo application\libraries\Github_updater.php.

Aparentemente, o erro estava no arquivo index.php que ao ser atualizado gerava o principal erro, proibi a alteração desse arquivo adicionando a linha 81 e 90; além de outros erros por não encontrar a pasta ou arquivo, para este caso eu crio o arquivo antes de copiar nas linhas 91 a 98.

