### PR TITLE
fix:valor-boleto-e-bd

### DIFF
--- a/application/helpers/general_helper.php
+++ b/application/helpers/general_helper.php
@@ -28,21 +28,12 @@ if (!function_exists('limitarTexto')) {
 if (!function_exists('getMoneyAsCents')) {
     function getMoneyAsCents($value)
     {
-        // strip out commas
-        $value = preg_replace("/\,/i", "", $value);
-
-        // strip out all but numbers, dash, and dot
-        $value = preg_replace('/[^0-9]/', '', $value);
-
         // make sure we are dealing with a proper number now, no +.4393 or 3...304 or 76.5895,94
         if (!is_numeric($value)) {
-            return 0.00;
+            throw new \InvalidArgumentException('A entrada deve ser numérica!');
         }
 
-        // convert to a float explicitly
-        $value = (float) $value;
-
-        return (int) round($value, 2) * 100;
+        return intval(round(floatval($value), 2) * 100);
     }
 }
 

--- a/application/libraries/Gateways/GerencianetSdk.php
+++ b/application/libraries/Gateways/GerencianetSdk.php
@@ -219,7 +219,7 @@ class GerencianetSdk extends BasePaymentGateway
                 [
                     'name' => $tipo === PaymentGateway::PAYMENT_TYPE_OS ? "OS #$id" : "Venda #$id",
                     'amount' => 1,
-                    'value' => round(($totalProdutos + $totalServicos),2)*100
+                    'value' => getMoneyAsCents($totalProdutos + $totalServicos)
                 ]
             ],
             'metadata' => [
@@ -246,7 +246,7 @@ class GerencianetSdk extends BasePaymentGateway
             'expire_at' => $result['data']['expire_at'],
             'charge_id' => $result['data']['charge_id'],
             'status' => $result['data']['status'],
-            'total' => round(($totalProdutos + $totalServicos),2)*100,
+            'total' => getMoneyAsCents($totalProdutos + $totalServicos),
             'payment' => $result['data']['payment'],
             'clientes_id' => $entity->idClientes,
             'payment_method' => 'boleto',
@@ -313,7 +313,7 @@ class GerencianetSdk extends BasePaymentGateway
                     [
                         'name' => $tipo === PaymentGateway::PAYMENT_TYPE_OS ? "OS #$id" : "Venda #$id",
                         'amount' => 1,
-                        'value' => round(($totalProdutos + $totalServicos),2)*100
+                        'value' => getMoneyAsCents($totalProdutos + $totalServicos)
                     ]
                 ],
                 'metadata' => [
@@ -348,7 +348,7 @@ class GerencianetSdk extends BasePaymentGateway
             'expire_at' => $result['data']['expire_at'],
             'charge_id' => $result['data']['charge_id'],
             'status' => $result['data']['status'],
-            'total' => round(($totalProdutos + $totalServicos),2)*100,
+            'total' => getMoneyAsCents($totalProdutos + $totalServicos),
             'clientes_id' => $entity->idClientes,
             'payment_method' => 'link',
             'payment_gateway' => 'GerencianetSdk',

--- a/application/libraries/Gateways/GerencianetSdk.php
+++ b/application/libraries/Gateways/GerencianetSdk.php
@@ -211,7 +211,7 @@ class GerencianetSdk extends BasePaymentGateway
                 'address' => $address,
             ];
         }
-
+        
         $expirationDate = (new DateTime())->add(new DateInterval($this->gerenciaNetConfig['boleto_expiration']));
         $expirationDate = ($expirationDate->format('Y-m-d'));
         $body = [
@@ -219,7 +219,7 @@ class GerencianetSdk extends BasePaymentGateway
                 [
                     'name' => $tipo === PaymentGateway::PAYMENT_TYPE_OS ? "OS #$id" : "Venda #$id",
                     'amount' => 1,
-                    'value' => getMoneyAsCents($totalProdutos + $totalServicos)
+                    'value' => round(($totalProdutos + $totalServicos),2)*100
                 ]
             ],
             'metadata' => [
@@ -246,7 +246,7 @@ class GerencianetSdk extends BasePaymentGateway
             'expire_at' => $result['data']['expire_at'],
             'charge_id' => $result['data']['charge_id'],
             'status' => $result['data']['status'],
-            'total' => getMoneyAsCents($totalProdutos + $totalServicos),
+            'total' => round(($totalProdutos + $totalServicos),2)*100,
             'payment' => $result['data']['payment'],
             'clientes_id' => $entity->idClientes,
             'payment_method' => 'boleto',
@@ -313,7 +313,7 @@ class GerencianetSdk extends BasePaymentGateway
                     [
                         'name' => $tipo === PaymentGateway::PAYMENT_TYPE_OS ? "OS #$id" : "Venda #$id",
                         'amount' => 1,
-                        'value' => getMoneyAsCents($totalProdutos + $totalServicos)
+                        'value' => round(($totalProdutos + $totalServicos),2)*100
                     ]
                 ],
                 'metadata' => [
@@ -348,7 +348,7 @@ class GerencianetSdk extends BasePaymentGateway
             'expire_at' => $result['data']['expire_at'],
             'charge_id' => $result['data']['charge_id'],
             'status' => $result['data']['status'],
-            'total' => getMoneyAsCents($totalProdutos + $totalServicos),
+            'total' => round(($totalProdutos + $totalServicos),2)*100,
             'clientes_id' => $entity->idClientes,
             'payment_method' => 'link',
             'payment_gateway' => 'GerencianetSdk',

--- a/application/libraries/Gateways/MercadoPago.php
+++ b/application/libraries/Gateways/MercadoPago.php
@@ -238,7 +238,7 @@ class MercadoPago extends BasePaymentGateway
             'expire_at' => $payment->date_of_expiration,
             'charge_id' => $payment->id,
             'status' => $payment->status,
-            'total' => getMoneyAsCents($totalProdutos + $totalServicos),
+            'total' => round(($totalProdutos + $totalServicos),2)*100,
             'clientes_id' => $entity->idClientes,
             'payment_method' => 'boleto',
             'payment_gateway' => 'MercadoPago',

--- a/application/libraries/Gateways/MercadoPago.php
+++ b/application/libraries/Gateways/MercadoPago.php
@@ -238,7 +238,7 @@ class MercadoPago extends BasePaymentGateway
             'expire_at' => $payment->date_of_expiration,
             'charge_id' => $payment->id,
             'status' => $payment->status,
-            'total' => round(($totalProdutos + $totalServicos),2)*100,
+            'total' => getMoneyAsCents($totalProdutos + $totalServicos),
             'clientes_id' => $entity->idClientes,
             'payment_method' => 'boleto',
             'payment_gateway' => 'MercadoPago',


### PR DESCRIPTION
Corrigido bug onde ao ter valor de centavos o valor do boleto vinha errado. Ex: 5,50 vinha no boleto 55,00 reais.
Corrido o valor que era salvo para o banco de dados que ocasionava o erro nas views cobranças e vizualizar cobrança.