### PR TITLE
Replace no cep para busca no WebService viacep 

### DIFF
--- a/assets/js/funcoes.js
+++ b/assets/js/funcoes.js
@@ -276,7 +276,7 @@ $(document).ready(function () {
                 $("#estado").val("...");
 
                 //Consulta o webservice viacep.com.br/
-                $.getJSON("https://viacep.com.br/ws/" + cep + "/json/?callback=?", function (dados) {
+                $.getJSON("https://viacep.com.br/ws/" + cep.replace(/\./g, '') + "/json/?callback=?", function (dados) {
 
                     if (!("erro" in dados)) {
                         //Atualiza os campos com os valores da consulta.


### PR DESCRIPTION
Para pesquisa no site "viacep.com" requer o campo cep limpo portando o replace e requerido.