### PR TITLE
Alterado cores dos gráficos do painel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Todas as alterações serão documentadas neste arquivo
 Formato baseado em [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 e [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.32.2] - 2021-04-16
+### Changed
+- Alteradas as cores dos gráficos do painel para melhor entendimento e leitura dos gráficos e adicionado comentário nas linhas para que os usuários possam alterar as cores mais facilmente. [@mikxingu](https://github.com/mikxingu)
+
 ## [4.32.1] - 2021-03-27
 
 ### Fixed

--- a/application/views/mapos/painel.php
+++ b/application/views/mapos/painel.php
@@ -378,7 +378,8 @@
                         },
                         series: [{
                                 name: 'Receita Líquida',
-                                negativeColor: '#00CED1',
+                                color: '#98CE00', //COR DO LADO POSITIVO DA BARRA "RECEITA LIQUIDA"
+                                negativeColor: '#00CED1', //COR DO LADO NEGATIVO DA BARRA "RECEITA LIQUIDA"
                                 data: [
                                     [<?php echo($financeiro_mes->VALOR_JAN_REC - $financeiro_mes->VALOR_JAN_DES); ?>],
                                     [<?php echo($financeiro_mes->VALOR_FEV_REC - $financeiro_mes->VALOR_FEV_DES); ?>],
@@ -396,7 +397,8 @@
                             },
                             {
                                 name: 'Receita Bruta',
-                                negativeColor: '#32CD32',
+                                color: '#5EB1BF',//COR DO LADO NEGATIVO DA BARRA "RECEITA BRUTA"
+                                negativeColor: '#D32D41',//COR DO LADO NEGATIVO DA BARRA "RECEITA BRUTA"
                                 data: [
                                     [<?php echo($financeiro_mes->VALOR_JAN_REC); ?>],
                                     [<?php echo($financeiro_mes->VALOR_FEV_REC); ?>],
@@ -414,7 +416,8 @@
                             },
                             {
                                 name: 'Despesas',
-                                negativeColor: '#FF6347',
+                                color: '#D84727', //COR DO LADO POSITIVO DA BARRA "DESPESAS"
+                                negativeColor: '#5EB1BF', //COR DO LADO NEGATIVO DA BARRA "DESPESAS"
                                 data: [
                                     [<?php echo($financeiro_mes->VALOR_JAN_DES); ?>],
                                     [<?php echo($financeiro_mes->VALOR_FEV_DES); ?>],
@@ -432,7 +435,8 @@
                             },
                             {
                                 name: 'Inadimplência',
-                                negativeColor: '#8B008B',
+                                color: '#EF7B45',//COR DO LADO POSITIVO DA BARRA "INADIMPLENCIA"
+                                negativeColor: '#D84727',//COR DO LADO NEGATIVO DA BARRA "INADIMPLENCIA"
                                 data: [
                                     [<?php echo($financeiro_mesinadipl->VALOR_JAN_REC); ?>],
                                     [<?php echo($financeiro_mesinadipl->VALOR_FEV_REC); ?>],
@@ -586,6 +590,7 @@
             var plot1 = jQuery.jqplot('chart-os', [data], {
                 seriesDefaults: {
                     // Make this a pie chart.
+                    seriesColors: ['#ffb703','#fb8500','#219ebc','#023047','#8ecae6','#e76f51'], //COR DE CADA BARRA DO GRAFICO DE PIZZA "ESTATISTICAS DE OS", ALTERAR CONFORME ORDEM DE EXIBICAO
                     renderer: jQuery.jqplot.PieRenderer,
                     rendererOptions: {
                         // Put data labels on the pie slices.
@@ -619,7 +624,7 @@
                 ];
                 var plot2 = jQuery.jqplot('chart-financeiro', [data2], {
 
-                    seriesColors: ["#9ACD32", "#FF8C00", "#EAA228", "#579575", "#839557", "#958c12", "#953579", "#4b5de4", "#d8b83f", "#ff5800", "#0085cc"],
+                    seriesColors: ["#98CE00", "#e76f51", "#EAA228", "#579575", "#839557", "#958c12", "#953579", "#4b5de4", "#d8b83f", "#ff5800", "#0085cc"], //COR DAS BARRAS DO GRAFICO "ESTATISTICAS FINANCEIRAS REALIZADAS"
                     seriesDefaults: {
                         // Make this a pie chart.
                         renderer: jQuery.jqplot.PieRenderer,
@@ -643,7 +648,7 @@
                 ];
                 var plot3 = jQuery.jqplot('chart-financeiro2', [data3], {
 
-                        seriesColors: ["#90EE90", "#FF0000", "#EAA228", "#579575", "#839557", "#958c12", "#953579", "#4b5de4", "#d8b83f", "#ff5800", "#0085cc"],
+                        seriesColors: ["#90be6d", "#f94144", "#EAA228", "#579575", "#839557", "#958c12", "#953579", "#4b5de4", "#d8b83f", "#ff5800", "#0085cc"],//COR DAS BARRAS DO GRAFICO "ESTATISTICAS FINANCEIRAS PENDENTE"
                         seriesDefaults: {
                             // Make this a pie chart.
                             renderer: jQuery.jqplot.PieRenderer,
@@ -669,7 +674,7 @@
                 ];
                 var plot4 = jQuery.jqplot('chart-financeiro-caixa', [data4], {
 
-                        seriesColors: ["#839557", "#d8b83f", "#d8b83f", "#ff5800", "#0085cc"],
+                        seriesColors: ["#2D3E00", "#58355E", "#d8b83f", "#ff5800", "#0085cc"], //COR DAS BARRAS DO GRAFICO "TOTAL EM CAIXA"
                         seriesDefaults: {
                             // Make this a pie chart.
                             renderer: jQuery.jqplot.PieRenderer,


### PR DESCRIPTION
Olá! conforme  comentado na issue #1344 , estou abrindo essa PR para atualizar as cores do gráficos do painel e comentar as linhas onde é feita essa alteração, para que os usuários possam mais facilmente encontrar onde editar as cores conforme queiram.
Meu objetivo com essa PR é incorporar essas cores em novas versões, pois acredito que as cores atuais dos gráficos causam uma certa confusão ao ler o gráfico, pois nas cores padrão, receitas estão na cor vermelha e despesas estão na cor verde.
Usei essas cores com uma palheta de cores, acredito que assim as cores estão mais harmônicas e o gráfico fica mais facil de ler.
Por favor, me avisem o que mais eu preciso alterar para que essa PR seja incorporada na próxima versão.
Desde já, muito obrigado!

Abaixo seguem fotos das novas cores:

Financeiro:
![Financeiro](https://user-images.githubusercontent.com/30123586/115037100-7fbf4a00-9ea4-11eb-9040-b3f8501572c9.png)

Estatisticas Financeiras:
![Pizza](https://user-images.githubusercontent.com/30123586/115037134-8948b200-9ea4-11eb-9a8b-5338320b905d.png)

Estatisticas de OS:
![OS](https://user-images.githubusercontent.com/30123586/115037166-91085680-9ea4-11eb-8226-d15884b8f7b8.png)

