### PR TITLE
Fix dockerfile

### DIFF
--- a/docker/etc/php/Dockerfile
+++ b/docker/etc/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM nanoninja/php-fpm:7.4
+FROM nanoninja/php-fpm:7.4.0
 
 # Permission for PHP to write in volumes
 RUN usermod -u 1000 www-data


### PR DESCRIPTION
Update to dockerfile to match Phpfm version package.
Tava tentando fazer deploy do Mapos pelo docker e não tava conseguindo. Acho que mudaram as versões do phpfpm, e com isso me retornava o erro:
<code>
ERROR: Service 'php-fpm' failed to build: manifest for nanoninja/php-fpm:7.4 not found: manifest unknown: manifest unknown
</code>.
Essa correção simples resolve o problema