### PR TITLE
Atualização arquivo configurar.php

### DIFF
--- a/application/views/mapos/configurar.php
+++ b/application/views/mapos/configurar.php
@@ -136,8 +136,8 @@
                             <label for="control_editos" class="control-label">Controle de edição de OS</label>
                             <div class="controls">
                                 <select name="control_editos" id="control_editos">
-                                    <option value="1">Sim</option>
-                                    <option value="0" <?= $configuration['control_editos'] == '0' ? 'selected' : ''; ?> >Não</option>
+                                    <option value="1">Não</option>
+                                    <option value="0" <?= $configuration['control_editos'] == '0' ? 'selected' : ''; ?> >Sim</option>
                                 </select>
                                 <span class="help-inline">Ativar ou desativar a permissão para alterar OS faturada e/ou cancelada.</span>
                             </div>


### PR DESCRIPTION
Estava invertido o campo de "Controle de edição de OS" em configurações/sistema/financeiro.
vem como padrao ao instalar "SIM" nas configurações porem não aparece na OS a opção de deletar/editar, foi feito a inversão da informação para corrigir o erro.