### PR TITLE
Alt. no editarVenda.php  não deixa faturar zerado

### DIFF
--- a/application/views/vendas/editarVenda.php
+++ b/application/views/vendas/editarVenda.php
@@ -274,25 +274,34 @@
             submitHandler: function(form) {
                 var dados = $(form).serialize();
                 $('#btn-cancelar-faturar').trigger('click');
-                $.ajax({
-                    type: "POST",
-                    url: "<?php echo base_url(); ?>index.php/vendas/faturar",
-                    data: dados,
-                    dataType: 'json',
-                    success: function(data) {
-                        if (data.result == true) {
-                            window.location.reload(true);
-                        } else {
-                            Swal.fire({
-                                type: "error",
-                                title: "Atenção",
-                                text: "Ocorreu um erro ao tentar faturar venda."
-                            });
-                            $('#progress-fatura').hide();
+                if (valor <= 0) {
+                    Swal.fire({
+                        type: "error",
+                        title: "Atenção",
+                        text: "Inserir Produtos"
+                    });
+                } else if (valor > 0) {
+                    $.ajax({
+                        type: "POST",
+                        url: "<?php echo base_url(); ?>index.php/vendas/faturar",
+                        data: dados,
+                        dataType: 'json',
+
+                        success: function(data) {
+                            if (data.result == true) {
+                                window.location.reload(true);
+                            } else {
+                                Swal.fire({
+                                    type: "error",
+                                    title: "Atenção",
+                                    text: "Ocorreu um erro ao tentar faturar venda."
+                                });
+                                $('#progress-fatura').hide();
+                            }
                         }
-                    }
-                });
-                return false;
+                    });
+                    return false;
+                }
             }
         });
         $("#produto").autocomplete({


### PR DESCRIPTION
Alteração no editarVenda.php  nas linhas 274 até 305 para não deixar faturar zerado como acontece atualmente.
Em vendas quando vai faturar ele deixa faturar zerado, agora com essa alteração ele dá uma mensagem pedindo pra adicionar produtos.
Quero contribuir no projeto.
Abraços