### PR TITLE
Bug Fix stock in os cancelled

### DIFF
--- a/application/controllers/Os.php
+++ b/application/controllers/Os.php
@@ -510,15 +510,20 @@ class Os extends MY_Controller
             }
         }
 
-        if ($produtos = $this->os_model->getProdutos($id)) {
-            $this->load->model('produtos_model');
-            if ($this->data['configuration']['control_estoque']) {
-                foreach ($produtos as $p) {
-                    $this->produtos_model->updateEstoque($p->produtos_id, $p->quantidade, '+');
-                    log_info('ESTOQUE: produto id ' . $p->produtos_id . ' teve baixa de estoque quantidade: ' . $p->quantidade);
+        $osStockRefund = $this->os_model->getById($id);
+        //Verifica para poder fazer a devolução do produto para o estoque caso OS seja excluida.
+        if (strtolower($osStockRefund->status) != "cancelado") {
+            if ($produtos = $this->os_model->getProdutos($id)) {
+                $this->load->model('produtos_model');
+                if ($this->data['configuration']['control_estoque']) {
+                    foreach ($produtos as $p) {
+                        $this->produtos_model->updateEstoque($p->produtos_id, $p->quantidade, '+');
+                        log_info('ESTOQUE: produto id ' . $p->produtos_id . ' teve baixa de estoque quantidade: ' . $p->quantidade);
+                    }
                 }
             }
         }
+
 
         $this->os_model->delete('servicos_os', 'os_id', $id);
         $this->os_model->delete('produtos_os', 'os_id', $id);

--- a/application/controllers/Os.php
+++ b/application/controllers/Os.php
@@ -227,6 +227,13 @@ class Os extends MY_Controller
             ];
             $os = $this->os_model->getById($this->input->post('idOs'));
 
+            //Verifica para poder fazer a devolução do produto para o estoque caso OS seja cancelada.
+            if (strtolower($os->status) != "cancelado") {
+                if (strtolower($this->input->post('status')) == "cancelado") {
+                    $this->devolucaoEstoque($this->input->post('idOs'));
+                }
+            }
+
             if ($this->os_model->edit('os', $data, 'idOs', $this->input->post('idOs')) == true) {
                 $this->load->model('mapos_model');
                 $this->load->model('usuarios_model');
@@ -261,6 +268,7 @@ class Os extends MY_Controller
                     }
                     $this->enviarOsPorEmail($idOs, $remetentes, 'Ordem de Serviço - Editada');
                 }
+
 
                 $this->session->set_flashdata('success', 'Os editada com sucesso!');
                 log_info('Alterou uma OS. ID: ' . $this->input->post('idOs'));
@@ -443,7 +451,7 @@ class Os extends MY_Controller
             if ($ValidarEmail) {
                 if (empty($this->data['result']->email) || !filter_var($this->data['result']->email, FILTER_VALIDATE_EMAIL)) {
                     $this->session->set_flashdata('error', 'Por favor preencha o email do cliente');
-                    redirect(site_url('os/visualizar/').$this->uri->segment(3));
+                    redirect(site_url('os/visualizar/') . $this->uri->segment(3));
                 }
             }
 
@@ -461,6 +469,19 @@ class Os extends MY_Controller
 
         $this->session->set_flashdata('success', 'O sistema está com uma configuração ativada para não notificar. Entre em contato com o administrador.');
         redirect(site_url('os'));
+    }
+
+    private function devolucaoEstoque($id)
+    {
+        if ($produtos = $this->os_model->getProdutos($id)) {
+            $this->load->model('produtos_model');
+            if ($this->data['configuration']['control_estoque']) {
+                foreach ($produtos as $p) {
+                    $this->produtos_model->updateEstoque($p->produtos_id, $p->quantidade, '+');
+                    log_info('ESTOQUE: produto id ' . $p->produtos_id . ' teve baixa de estoque quantidade: ' . $p->quantidade);
+                }
+            }
+        }
     }
 
     public function excluir()

--- a/application/controllers/Os.php
+++ b/application/controllers/Os.php
@@ -478,7 +478,7 @@ class Os extends MY_Controller
             if ($this->data['configuration']['control_estoque']) {
                 foreach ($produtos as $p) {
                     $this->produtos_model->updateEstoque($p->produtos_id, $p->quantidade, '+');
-                    log_info('ESTOQUE: produto id ' . $p->produtos_id . ' teve baixa de estoque quantidade: ' . $p->quantidade);
+                    log_info('ESTOQUE: Produto id ' . $p->produtos_id . ' voltou ao estoque. Quantidade: ' . $p->quantidade. '. Motivo: Cancelamento/Exclusão');
                 }
             }
         }
@@ -518,7 +518,7 @@ class Os extends MY_Controller
                 if ($this->data['configuration']['control_estoque']) {
                     foreach ($produtos as $p) {
                         $this->produtos_model->updateEstoque($p->produtos_id, $p->quantidade, '+');
-                        log_info('ESTOQUE: produto id ' . $p->produtos_id . ' teve baixa de estoque quantidade: ' . $p->quantidade);
+                        log_info('ESTOQUE: Produto id ' . $p->produtos_id . ' voltou ao estoque. Quantidade: ' . $p->quantidade. '. Motivo: Cancelamento/Exclusão');
                     }
                 }
             }

--- a/application/views/mapos/configurar.php
+++ b/application/views/mapos/configurar.php
@@ -128,8 +128,8 @@
                             <label for="control_baixa" class="control-label">Controle de baixa retroativa</label>
                             <div class="controls">
                                 <select name="control_baixa" id="control_baixa">
-                                    <option value="1">Sim</option>
-                                    <option value="0" <?= $configuration['control_baixa'] == '0' ? 'selected' : ''; ?>>Não</option>
+                                    <option value="1">Ativar</option>
+                                    <option value="0" <?= $configuration['control_baixa'] == '0' ? 'selected' : ''; ?>>Desativar</option>
                                 </select>
                                 <span class="help-inline">Ativar ou desativar o controle de baixa financeira, com data retroativa.</span>
                             </div>
@@ -138,8 +138,8 @@
                             <label for="control_editos" class="control-label">Controle de edição de OS</label>
                             <div class="controls">
                                 <select name="control_editos" id="control_editos">
-                                    <option value="1" <?= $configuration['control_editos'] == '0' ? 'selected' : ''; ?>>Sim</option>
-                                    <option value="0" <?= $configuration['control_editos'] == '0' ? 'selected' : ''; ?>>Não</option>
+                                    <option value="1" <?= $configuration['control_editos'] == '0' ? 'selected' : ''; ?>>Ativar</option>
+                                    <option value="0" <?= $configuration['control_editos'] == '0' ? 'selected' : ''; ?>>Desativar</option>
                                 </select>
                                 <span class="help-inline">Ativar ou desativar a permissão para alterar OS faturada e/ou cancelada.</span>
                             </div>
@@ -166,8 +166,8 @@
                             <label for="control_estoque" class="control-label">Controlar Estoque</label>
                             <div class="controls">
                                 <select name="control_estoque" id="control_estoque">
-                                    <option value="1">Sim</option>
-                                    <option value="0" <?= $configuration['control_estoque'] == '0' ? 'selected' : ''; ?>>Não</option>
+                                    <option value="1">Ativar</option>
+                                    <option value="0" <?= $configuration['control_estoque'] == '0' ? 'selected' : ''; ?>>Desativar</option>
                                 </select>
                                 <span class="help-inline">Ativar ou desativar o controle de estoque.</span>
                             </div>

--- a/application/views/os/editarOs.php
+++ b/application/views/os/editarOs.php
@@ -226,7 +226,7 @@
                                                 echo '<td>' . $p->descricao . '</td>';
                                                 echo '<td><div align="center">' . $p->quantidade . '</td>';
                                                 echo '<td><div align="center">R$: ' . ($p->preco ?: $p->precoVenda)  . '</td>';
-                                                echo '<td><div align="center"><a href="" idAcao="' . $p->idProdutos_os . '" prodAcao="' . $p->idProdutos . '" quantAcao="' . $p->quantidade . '" title="Excluir Produto" class="btn-nwe4"><i class="bx bx-trash-alt"></i></a></td>';
+                                                echo (strtolower($result->status) != "cancelado") ? '<td><div align="center"><a href="" idAcao="' . $p->idProdutos_os . '" prodAcao="' . $p->idProdutos . '" quantAcao="' . $p->quantidade . '" title="Excluir Produto" class="btn-nwe4"><i class="bx bx-trash-alt"></i></a></td>' : '<td></td>';
                                                 echo '<td><div align="center">R$: ' . number_format($p->subTotal, 2, ',', '.') . '</td>';
                                                 echo '</tr>';
                                             } ?>

--- a/application/views/os/os.php
+++ b/application/views/os/os.php
@@ -164,7 +164,7 @@
                             if ($editavel) {
                                 echo '<a style="margin-right: 1%" href="' . base_url() . 'index.php/os/editar/' . $r->idOs . '" class="btn-nwe3" title="Editar OS"><i class="bx bx-edit"></i></a>';
                             }
-                            if ($this->permission->checkPermission($this->session->userdata('permissao'), 'dOs') && $editavel) {
+                            if ($this->permission->checkPermission($this->session->userdata('permissao'), 'dOs') && $editavel && strtolower($r->status) != "cancelado") {
                                 echo '<a href="#modal-excluir" role="button" data-toggle="modal" os="' . $r->idOs . '" class="btn-nwe4" title="Excluir OS"><i class="bx bx-trash-alt"></i></a>  ';
                             }
                             echo '</td>';

--- a/application/views/os/os.php
+++ b/application/views/os/os.php
@@ -164,7 +164,7 @@
                             if ($editavel) {
                                 echo '<a style="margin-right: 1%" href="' . base_url() . 'index.php/os/editar/' . $r->idOs . '" class="btn-nwe3" title="Editar OS"><i class="bx bx-edit"></i></a>';
                             }
-                            if ($this->permission->checkPermission($this->session->userdata('permissao'), 'dOs') && $editavel && strtolower($r->status) != "cancelado") {
+                            if ($this->permission->checkPermission($this->session->userdata('permissao'), 'dOs') && $editavel) {
                                 echo '<a href="#modal-excluir" role="button" data-toggle="modal" os="' . $r->idOs . '" class="btn-nwe4" title="Excluir OS"><i class="bx bx-trash-alt"></i></a>  ';
                             }
                             echo '</td>';


### PR DESCRIPTION
Fixed product return in stock when canceling OS.

Rename text in select Retroactive write-off control and OS edit control to active and desactive.

Disabled delete OS in status canceled