### PR TITLE
Remoção de linhas na impressão de Vendas

### DIFF
--- a/application/views/vendas/imprimirVenda.php
+++ b/application/views/vendas/imprimirVenda.php
@@ -119,7 +119,6 @@
                                         echo '<td>' . ($p->preco ?: $p->precoVenda) . '</td>';
                                         echo '<td> ' . number_format($p->subTotal, 2, ',', '.') . '</td>';
                                         echo '</tr>';
-                                        echo '<hr />';
                                     } ?>
                                     <tr>
                                         <td colspan="4" style="text-align: right"><strong>Total:</strong></td>


### PR DESCRIPTION
- Ao realizar uma impressão de venda, é gerado algumas linhas a mais sem necessidade.
![image](https://github.com/RamonSilva20/mapos/assets/70410692/f7bb7f7c-4b69-4068-bf3a-ceb427144785)

- Correção aplicada somente na view de impressão.
![image](https://github.com/RamonSilva20/mapos/assets/70410692/70077a20-512e-4649-9886-9b8b18c901b4)