### PR TITLE
Fix\Erro no Upload na OS (aba Anexos)

### DIFF
--- a/application/controllers/Os.php
+++ b/application/controllers/Os.php
@@ -790,35 +790,53 @@ class Os extends MY_Controller
                 $error['upload'][] = $this->upload->display_errors();
             } else {
                 $upload_data = $this->upload->data();
-
+        
+                // Gera um nome de arquivo aleatório mantendo a extensão original
+                $new_file_name = uniqid() . '.' . pathinfo($upload_data['file_name'], PATHINFO_EXTENSION);
+                $new_file_path = $upload_data['file_path'] . $new_file_name;
+        
+                rename($upload_data['full_path'], $new_file_path);
+        
                 if ($upload_data['is_image'] == 1) {
-                    // set the resize config
                     $resize_conf = [
-
-                        'source_image' => $upload_data['full_path'],
-                        'new_image' => $upload_data['file_path'] . 'thumbs' . DIRECTORY_SEPARATOR . 'thumb_' . $upload_data['file_name'],
+                        'source_image' => $new_file_path,
+                        'new_image' => $upload_data['file_path'] . 'thumbs' . DIRECTORY_SEPARATOR . 'thumb_' . $new_file_name,
                         'width' => 200,
                         'height' => 125,
                     ];
-
+        
                     $this->image_lib->initialize($resize_conf);
-
+        
                     if (!$this->image_lib->resize()) {
                         $error['resize'][] = $this->image_lib->display_errors();
                     } else {
                         $success[] = $upload_data;
                         $this->load->model('Os_model');
-                        $this->Os_model->anexar($this->input->post('idOsServico'), $upload_data['file_name'], base_url('assets' . DIRECTORY_SEPARATOR . 'anexos' . DIRECTORY_SEPARATOR . date('m-Y') . DIRECTORY_SEPARATOR . 'OS-' . $this->input->post('idOsServico')), 'thumb_' . $upload_data['file_name'], $directory);
+                        $result = $this->Os_model->anexar($this->input->post('idOsServico'), $new_file_name, base_url('assets' . DIRECTORY_SEPARATOR . 'anexos' . DIRECTORY_SEPARATOR . date('m-Y') . DIRECTORY_SEPARATOR . 'OS-' . $this->input->post('idOsServico')), 'thumb_' . $new_file_name, $directory);
+                        if (!$result) {
+                            $error['db'][] = 'Erro ao inserir no banco de dados.';
+                        }
                     }
                 } else {
                     $success[] = $upload_data;
-
+        
                     $this->load->model('Os_model');
-
-                    $this->Os_model->anexar($this->input->post('idOsServico'), $upload_data['file_name'], base_url('assets' . DIRECTORY_SEPARATOR . 'anexos' . DIRECTORY_SEPARATOR . date('m-Y') . DIRECTORY_SEPARATOR . 'OS-' . $this->input->post('idOsServico')), '', $directory);
+        
+                    $result = $this->Os_model->anexar($this->input->post('idOsServico'), $new_file_name, base_url('assets' . DIRECTORY_SEPARATOR . 'anexos' . DIRECTORY_SEPARATOR . date('m-Y') . DIRECTORY_SEPARATOR . 'OS-' . $this->input->post('idOsServico')), '', $directory);
+                    if (!$result) {
+                        $error['db'][] = 'Erro ao inserir no banco de dados.';
+                    }
                 }
             }
         }
+        
+        if (count($error) > 0) {
+            echo json_encode(['result' => false, 'mensagem' => 'Ocorreu um erro ao processar os arquivos.', 'errors' => $error]);
+        } else {
+            log_info('Adicionou anexo(s) a uma OS. ID (OS): ' . $this->input->post('idOsServico'));
+            echo json_encode(['result' => true, 'mensagem' => 'Arquivo(s) anexado(s) com sucesso.']);
+        }
+    }
 
         if (count($error) > 0) {
             echo json_encode(['result' => false, 'mensagem' => 'Nenhum arquivo foi anexado.']);


### PR DESCRIPTION
Identificado erro no upload de arquivos na OS (aba Anexos) em que o arquivo  possui o nome muito extenso, em que não é upado devido a Coluna thumbs da tabela Anexos estar configurado para VARCHAR(45), e no momento da exclusão ficar carregando infinitamente no Map-OS, visando não aumentar o valor no banco de dados e sim corrigir o tratamento do PHP para que o INSERT não tenha mais o nome extenso e com caracteres especiais, fiz uma modificação no script em que é alterado o nome do arquivo para uma sequencia aleatória de letras e números, respeitando o limite do banco de 45 caracteres.

Erro apresentado:
![Imagem do WhatsApp de 2023-08-18 à(s) 20 35 22](https://github.com/RamonSilva20/mapos/assets/45976190/b7227bf6-620d-4eb9-88f7-eea36f423f61)
![Imagem do WhatsApp de 2023-08-18 à(s) 20 31 32](https://github.com/RamonSilva20/mapos/assets/45976190/2e94e2b7-6e66-41ca-834d-1767835678fa)


Após correção:
![Imagem do WhatsApp de 2023-08-18 à(s) 22 56 45](https://github.com/RamonSilva20/mapos/assets/45976190/3c1619d3-221c-4967-adf9-0f6e389e1e5b)
![Imagem do WhatsApp de 2023-08-18 à(s) 22 56 49](https://github.com/RamonSilva20/mapos/assets/45976190/0390c2c9-15a0-4cb0-a592-d23ec843751e)

