### PR TITLE
v4.41.0 - Erro na aba OS

### DIFF
--- a/application/controllers/Os.php
+++ b/application/controllers/Os.php
@@ -844,14 +844,6 @@ class Os extends MY_Controller
         }
     }
 
-        if (count($error) > 0) {
-            echo json_encode(['result' => false, 'mensagem' => 'Nenhum arquivo foi anexado.']);
-        } else {
-            log_info('Adicionou anexo(s) a uma OS. ID (OS): ' . $this->input->post('idOsServico'));
-            echo json_encode(['result' => true, 'mensagem' => 'Arquivo(s) anexado(s) com sucesso .']);
-        }
-    }
-
     public function excluirAnexo($id = null)
     {
         if ($id == null || !is_numeric($id)) {


### PR DESCRIPTION
Olá, identificado desvio na aba Ordem de Serviço devido a PR #2180 .
Segue correção.

Remoção das linhas 846 até 853.

![Imagem do WhatsApp de 2023-09-16 à(s) 12 24 43](https://github.com/RamonSilva20/mapos/assets/45976190/20835713-ee3c-4938-bdd8-c99717181a8a)
