### PR TITLE
Correção da instalação via docker

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,68 +1,68 @@
-version: '2'
+version: "3.9"
 services:
-    nginx:
-        image: nginx:alpine
-        container_name: nginx
-        volumes:
-            - "./etc/nginx/default.conf:/etc/nginx/conf.d/default.conf"
-            - "../:/var/www/html"
-            - "./etc/nginx/default.template.conf:/etc/nginx/conf.d/default.template"
-        ports:
-            - "${NGINX_PORT}:${NGINX_PORT}"
-        env_file:
-            - ".env"
-        command: /bin/sh -c "envsubst '$$NGINX_HOST $$NGINX_PORT' < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
-        restart: always
-        depends_on:
-            - php-fpm
-            - mysql
+  nginx:
+    image: nginx:alpine
+    container_name: nginx
+    volumes:
+      - "./etc/nginx/default.conf:/etc/nginx/conf.d/default.conf"
+      - "../:/var/www/html"
+      - "./etc/nginx/default.template.conf:/etc/nginx/conf.d/default.template"
+    ports:
+      - "${NGINX_PORT}:${NGINX_PORT}"
+    env_file:
+      - ".env"
+    command: /bin/sh -c "envsubst '$$NGINX_HOST $$NGINX_PORT' < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
+    restart: always
+    depends_on:
+      - php-fpm
+      - mysql
 
-    php-fpm:
-        container_name: php-fpm
-        build:
-            context: ./etc/php
-            dockerfile: Dockerfile
-        restart: always
-        volumes:
-            - "./etc/php/php.ini:/usr/local/etc/php/conf.d/php.ini"
-            - "./etc/php/uploads.ini:/usr/local/etc/php/conf.d/uploads.ini"
-            - "../:/var/www/html"
+  php-fpm:
+    container_name: php-fpm
+    build:
+      context: ./etc/php
+      dockerfile: Dockerfile
+    restart: always
+    volumes:
+      - "./etc/php/php.ini:/usr/local/etc/php/conf.d/php.ini"
+      - "./etc/php/uploads.ini:/usr/local/etc/php/conf.d/uploads.ini"
+      - "../:/var/www/html"
 
-    composer:
-        container_name: composer
-        build:
-            context: ./etc/composer
-            dockerfile: Dockerfile
-        volumes:
-            - "../:/app"
-        command: install --ignore-platform-reqs --no-scripts
+  composer:
+    container_name: composer
+    build:
+      context: ./etc/composer
+      dockerfile: Dockerfile
+    volumes:
+      - "../:/app"
+    command: install --ignore-platform-reqs --no-scripts
 
-    phpmyadmin:
-        image: phpmyadmin/phpmyadmin
-        container_name: phpmyadmin
-        ports:
-            - "${PHP_MY_ADMIN_PORT}:80"
-        environment:
-            - PMA_ARBITRARY=1
-            - PMA_HOST=${MYSQL_MAPOS_HOST}
-            - PMA_USER=${MYSQL_MAPOS_USER}
-            - PMA_PASSWORD=${MYSQL_MAPOS_PASSWORD}
-        restart: always
-        depends_on:
-            - mysql
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    container_name: phpmyadmin
+    ports:
+      - "${PHP_MY_ADMIN_PORT}:80"
+    environment:
+      - PMA_ARBITRARY=1
+      - PMA_HOST=${MYSQL_MAPOS_HOST}
+      - PMA_USER=${MYSQL_MAPOS_USER}
+      - PMA_PASSWORD=${MYSQL_MAPOS_PASSWORD}
+    restart: always
+    depends_on:
+      - mysql
 
-    mysql:
-        image: mysql:${MYSQL_MAPOS_VERSION}
-        container_name: mysql
-        restart: always
-        env_file:
-            - ".env"
-        environment:
-            - MYSQL_DATABASE=${MYSQL_MAPOS_DATABASE}
-            - MYSQL_ROOT_PASSWORD=${MYSQL_MAPOS_ROOT_PASSWORD}
-            - MYSQL_USER=${MYSQL_MAPOS_USER}
-            - MYSQL_PASSWORD=${MYSQL_MAPOS_PASSWORD}
-        ports:
-            - "${MYSQL_MAPOS_PORT}:3306"
-        volumes:
-            - "./data/db/mysql:/var/lib/mysql"
+  mysql:
+    image: mysql:${MYSQL_MAPOS_VERSION}
+    container_name: mysql
+    restart: always
+    env_file:
+      - ".env"
+    environment:
+      - MYSQL_DATABASE=${MYSQL_MAPOS_DATABASE}
+      - MYSQL_ROOT_PASSWORD=${MYSQL_MAPOS_ROOT_PASSWORD}
+      - MYSQL_USER=${MYSQL_MAPOS_USER}
+      - MYSQL_PASSWORD=${MYSQL_MAPOS_PASSWORD}
+    ports:
+      - "${MYSQL_MAPOS_PORT}:3306"
+    volumes:
+      - "./data/db/mysql:/var/lib/mysql"

--- a/docker/etc/php/Dockerfile
+++ b/docker/etc/php/Dockerfile
@@ -1,8 +1,8 @@
 FROM php:8.2.5-fpm
 
 # Install extension
-RUN apt-get update && apt-get upgrade -y \
-    && apt-get install -y \
+RUN apt update && apt upgrade -y \
+    && apt install -y \
     g++ \
     libbz2-dev \
     libc-client-dev \
@@ -52,8 +52,8 @@ RUN apt-get update && apt-get upgrade -y \
     && pecl install redis && docker-php-ext-enable redis \
     && yes '' | pecl install imagick && docker-php-ext-enable imagick \
     && docker-php-source delete \
-    && apt-get remove -y g++ wget \
-    && apt-get autoremove --purge -y && apt-get autoclean -y && apt-get clean -y \
+    && apt remove -y g++ wget \
+    && apt autoremove --purge -y && apt autoclean -y && apt clean -y \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/* /var/tmp/*
 
@@ -61,7 +61,7 @@ RUN apt-get update && apt-get upgrade -y \
 RUN usermod -u 1000 www-data
 
 # Install supervisor and cron
-RUN apt-get update && apt-get install supervisor cron -y
+RUN apt update && apt install supervisor cron -y
 
 # Setup cron jobs
 RUN touch /var/log/cron.log


### PR DESCRIPTION
**Descrição**

Olá, sou Matheus Vieira Dev Web Fullstack. Hoje eu baixei a aplicação para usar aqui na minha gráfica e como eu tenho o docker instalado na minha máquina, optei pela instalação pelo docker, como está previsto no README.md

Mas em determinada altura do pulling e criação das imagens a aplicação encerrava com a exceção de que não foi possível se conectar com os repositórios debian para baixar os pacotes.

Então eu verifiquei que o repositório (este) da aplicação é público e resolvi ajudar.

Pois bem, o arquivo docker-compose dentro da pasta "docker", apesar de estar muito bem escrito, estava usando uma versão antiga, a 2, então eu atualizei para a versão 3.9 que é a mais atual. Também verifiquei o arquivo Dockerfile na pasta "docker>etc>php" e vi que a instrução RUN tinha comandos com a sintaxe "apt-get [ ... ]", fiz apenas uma pequena mudança para a sintaxe que usa apenas o apt (mais atual).

Após essas alterações, executei uma bateria de testes e a aplicação funcionou perfeitamente no endereço "localhost:8000/install/index.php" para fazer a instalação e "localhost:8000" para a execução do sistema.

Se for o caso de eu ter sido por demais intrometido, peço desculpas, a intenção é só ajudar mesmo.

**Tipo de alteração**

- [x] Correção de bug

**Checklist**

- [x] Minhas alterações não deletam partes do projeto
- [x] Minhas alterações não introduzem novos problemas
- [x] Minha contribuição resolve um problema

**Comentários adicionais**

N/A
