### PR TITLE
Feature/Botao Imprimir Suspenso OS

### DIFF
--- a/application/views/os/editarOs.php
+++ b/application/views/os/editarOs.php
@@ -24,10 +24,16 @@
                     } ?>
                     <a title="Visualizar OS" class="button btn btn-primary" href="<?php echo site_url() ?>/os/visualizar/<?php echo $result->idOs; ?>">
                         <span class="button__icon"><i class="bx bx-show"></i></span><span class="button__text">Visualizar OS</span></a>
-                    <a target="_blank" title="Imprimir OS Papel A4" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/os/imprimir/<?php echo $result->idOs; ?>">
-                        <span class="button__icon"><i class="bx bx-printer"></i></span> <span class="button__text">Papel A4</span></a>
-                    <a target="_blank" title="Imprimir OS Cupom Não Fiscal" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/os/imprimirTermica/<?php echo $result->idOs; ?>">
-                        <span class="button__icon"><i class="bx bx-printer"></i></span> <span class="button__text">CP Não Fiscal</span></a>
+                    <div class="button-container">
+                        <a target="_blank" title="Imprimir OS Papel A4" class="button btn btn-mini btn-inverse">
+                            <span class="button__icon"><i class="bx bx-printer"></i></span><span class="button__text">Imprimir</span></a>
+                        <div class="cascading-buttons">
+                            <a target="_blank" title="Imprimir OS Papel A4" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/os/imprimir/<?php echo $result->idOs; ?>">
+                                <span class="button__icon"><i class='bx bx-file' ></i></span> <span class="button__text">Papel A4</span></a>
+                            <a target="_blank" title="Imprimir OS Cupom Não Fiscal" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/os/imprimirTermica/<?php echo $result->idOs; ?>">
+                                <span class="button__icon"><i class='bx bx-receipt'></i></span> <span class="button__text">CP Não Fiscal</span></a>
+                        </div>
+                    </div>
                     <?php if ($this->permission->checkPermission($this->session->userdata('permissao'), 'eOs')) {
                         $this->load->model('os_model');
                         $zapnumber = preg_replace("/[^0-9]/", "", $result->celular_cliente);

--- a/application/views/os/visualizarOs.php
+++ b/application/views/os/visualizarOs.php
@@ -12,11 +12,16 @@
                         echo '<a title="Editar OS" class="button btn btn-mini btn-success" href="' . base_url() . 'index.php/os/editar/' . $result->idOs . '">
     <span class="button__icon"><i class="bx bx-edit"></i> </span> <span class="button__text">Editar</span></a>';
                     } ?>
-
-                    <a target="_blank" title="Imprimir OS" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/os/imprimir/<?php echo $result->idOs; ?>">
-                        <span class="button__icon"><i class="bx bx-printer"></i></span> <span class="button__text">Papel A4</span></a>
-                    <a target="_blank" title="Imprimir OS" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/os/imprimirTermica/<?php echo $result->idOs; ?>">
-                        <span class="button__icon"><i class="bx bx-printer"></i></span> <span class="button__text">CP Não Fiscal</span></a>
+                    <div class="button-container">
+                        <a target="_blank" title="Imprimir OS Papel A4" class="button btn btn-mini btn-inverse">
+                            <span class="button__icon"><i class="bx bx-printer"></i></span><span class="button__text">Imprimir</span></a>
+                        <div class="cascading-buttons">
+                            <a target="_blank" title="Imprimir OS Papel A4" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/os/imprimir/<?php echo $result->idOs; ?>">
+                                <span class="button__icon"><i class='bx bx-file' ></i></span> <span class="button__text">Papel A4</span></a>
+                            <a target="_blank" title="Imprimir OS Cupom Não Fiscal" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/os/imprimirTermica/<?php echo $result->idOs; ?>">
+                                <span class="button__icon"><i class='bx bx-receipt'></i></span> <span class="button__text">CP Não Fiscal</span></a>
+                        </div>
+                    </div>
                     <?php if ($this->permission->checkPermission($this->session->userdata('permissao'), 'eOs')) {
                         $this->load->model('os_model');
                         $zapnumber = preg_replace("/[^0-9]/", "", $result->celular_cliente);

--- a/application/views/vendas/visualizarVenda.php
+++ b/application/views/vendas/visualizarVenda.php
@@ -12,12 +12,18 @@
                         echo '<a title="Editar Venda" class="button btn btn-mini btn-success" href="' . base_url() . 'index.php/vendas/editar/' . $result->idVendas . '">
     <span class="button__icon"><i class="bx bx-edit"></i> </span> <span class="button__text">Editar</span></a>';
                     } ?>
-                    <a target="_blank" title="Imprimir Orcamento A4" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/vendas/imprimirVendaOrcamento/<?php echo $result->idVendas; ?>">
-                        <span class="button__icon"><i class="bx bx-printer"></i></span> <span class="button__text">Orçamento</span></a>
-                    <a target="_blank" title="Imprimir Papel A4" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/vendas/imprimir/<?php echo $result->idVendas; ?>">
-                        <span class="button__icon"><i class="bx bx-printer"></i></span> <span class="button__text">Papel A4</span></a>
-                    <a target="_blank" title="Imprimir Cupom Não Fiscal" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/vendas/imprimirTermica/<?php echo $result->idVendas; ?>">
-                        <span class="button__icon"><i class="bx bx-printer"></i></span> <span class="button__text">CP Não Fiscal</span></a>
+                    <div class="button-container">
+                        <a target="_blank" title="Imprimir OS Papel A4" class="button btn btn-mini btn-inverse">
+                            <span class="button__icon"><i class="bx bx-printer"></i></span><span class="button__text">Imprimir</span></a>
+                        <div class="cascading-buttons">
+                            <a target="_blank" title="Imprimir Orcamento A4" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/vendas/imprimirVendaOrcamento/<?php echo $result->idVendas; ?>">
+                                <span class="button__icon"><i class="bx bx-dollar-circle"></i></span> <span class="button__text">Orçamento</span></a>
+                            <a target="_blank" title="Imprimir Papel A4" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/vendas/imprimir/<?php echo $result->idVendas; ?>">
+                                <span class="button__icon"><i class="bx bx-file"></i></span> <span class="button__text">Papel A4</span></a>
+                            <a target="_blank" title="Imprimir Cupom Não Fiscal" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/vendas/imprimirTermica/<?php echo $result->idVendas; ?>">
+                                <span class="button__icon"><i class="bx bx-receipt"></i></span> <span class="button__text">CP Não Fiscal</span></a>
+                        </div>
+                    </div>
                     <a href="#modal-gerar-pagamento" id="btn-forma-pagamento" role="button" data-toggle="modal" class="button btn btn-mini btn-info">
                         <span class="button__icon"><i class='bx bx-qr'></i></span><span class="button__text">Gerar Pagamento</span></a></i>
                 </div>

--- a/assets/css/matrix-style.css
+++ b/assets/css/matrix-style.css
@@ -3388,7 +3388,7 @@ form {
     float : left;
     margin: 0 8px;
   }
-
+  
   .panel-left {
     margin-right: 0;
   }
@@ -3780,6 +3780,15 @@ form {
   }
 
   .widget-title .buttons>.btn {
+    width      : 32px !important;
+    min-width  : 32px;
+    white-space: nowrap;
+    overflow   : hidden;
+    position   : relative;
+    left       : 3px;
+  }
+
+  .widget-title .buttons .button-container>.btn {
     width      : 32px !important;
     min-width  : 32px;
     white-space: nowrap;
@@ -4284,4 +4293,28 @@ fieldset[disabled] .btn-info.active {
 
 .table th, .table td{
   border-left: 0px solid #ddd;
+}
+
+/* Ajuste botões de impressão */
+.button-container {
+  position: relative;
+  display: inline-block;
+  margin: none;
+}
+
+.cascading-buttons {
+  display: none;
+  position: absolute;
+  top: 85%;
+  left: 0;
+  border-top: none;
+  z-index: 1;
+}
+
+.button-container:hover .cascading-buttons {
+  display: block;
+}
+
+.button-container .cascading-buttons a {
+  margin: 0 0 3px 0;
 }


### PR DESCRIPTION
Olá Srs,
Visando que a quantidade de tipos de impressão está crescendo dentro do projeto, eu e @Fesantt desenvolvemos uma melhoria com objetivo de otimizar a navegação e visualização do usuário desktop e mobile, criamos um menu suspenso para listar os tipos de impressão nas páginas visualizar OS/Vendas e editar OS, dando um espaço adequado para PRs futuras que visão a variedade de tipos de impressão.

Desktop/Tablet:
![image](https://github.com/RamonSilva20/mapos/assets/45976190/2f0a6b2b-77ea-4fe1-9f33-1bab33b491bb)
![image](https://github.com/RamonSilva20/mapos/assets/45976190/b2b5be2c-e8fe-4625-888e-5965af016455)
![image](https://github.com/RamonSilva20/mapos/assets/45976190/3f25fa72-9afb-4db7-86d4-7b297e58bca5)

Mobile
![image](https://github.com/RamonSilva20/mapos/assets/45976190/ce4818c1-4d28-4702-bed5-11f71566792f)
![image](https://github.com/RamonSilva20/mapos/assets/45976190/da1ce653-3010-405e-8693-a1533a177826)
![image](https://github.com/RamonSilva20/mapos/assets/45976190/a777e135-8f7d-4d99-8924-17c38cd52458)
