### PR TITLE
Correção de lançamento parcelado

### DIFF
--- a/application/controllers/Financeiro.php
+++ b/application/controllers/Financeiro.php
@@ -283,19 +283,12 @@ class Financeiro extends MY_Controller
                         'data_pagamento' => $recebimento ?: date_format($myDateTime, "Y-m-d"),
                         'baixado' => 0,
                         'cliente_fornecedor' => $this->input->post('cliente_parc'),
+                        'clientes_id ' => $this->input->post('idCliente_parc'),
                         'observacoes' => $this->input->post('observacoes_parc'),
                         'forma_pgto' => $this->input->post('formaPgto_parc'),
                         'tipo' => $this->input->post('tipo_parc'),
                         'usuarios_id' => $this->session->userdata('id_admin'),
-
                     ];
-
-                    if (set_value('idFornecedor')) {
-                        $data['clientes_id'] = set_value('idFornecedor');
-                    }
-                    if (set_value('idCliente')) {
-                        $data['clientes_id'] = set_value('idCliente');
-                    }
 
                     if ($this->financeiro_model->add('lancamentos', $data) == true) {
                         $this->session->set_flashdata('success', 'Lançamento adicionado com sucesso!');
@@ -319,13 +312,11 @@ class Financeiro extends MY_Controller
                     'data_pagamento' => $dia_pgto != null ? $dia_pgto : date_format("Y-m-d"),
                     'baixado' => 1,
                     'cliente_fornecedor' => $this->input->post('cliente_parc'),
+                    'clientes_id' => $this->input->post('idCliente_parc'),
                     'observacoes' => $this->input->post('observacoes_parc'),
                     'forma_pgto' => $this->input->post('formaPgto_parc'),
                     'tipo' => $this->input->post('tipo_parc'),
                     'usuarios_id' => $this->session->userdata('id_admin'),
-
-
-
                 ];
                 // if (empty($data['valor_desconto'])) {
                 //     $data['valor_desconto'] =  "0";

--- a/application/views/financeiro/lancamentos.php
+++ b/application/views/financeiro/lancamentos.php
@@ -392,7 +392,7 @@ echo number_format($soma_descontos_pagos, 2, ',', '.')?></strong></td>
     		<div class="span6" style="margin-left: 0"> 
     			<label for="cliente_parc">Cliente/Fornecedor*</label>
     			<input class="span11" id="cliente_parc" type="text" name="cliente_parc" required />
-                <input class="span11" id="idCliente" type="hidden" name="idCliente" value="" />
+                <input class="span11" id="idCliente_parc" type="hidden" name="idCliente_parc" value="" />
     		</div>
 		
 			<div class="span6" style="margin-left: 0">
@@ -993,6 +993,7 @@ echo number_format($soma_descontos_pagos, 2, ',', '.')?></strong></td>
             minLength: 1,
             select: function(event, ui) {
                 $("#cliente_parc").val(ui.item.label);
+                $("#idCliente_parc").val(ui.item.id);
             }
         });
 
@@ -1037,6 +1038,7 @@ echo number_format($soma_descontos_pagos, 2, ',', '.')?></strong></td>
 				$('#abrirmodalreceitaparcelada').trigger('click');
 				$("#descricao_parc").val($("#descricao").val());
 				$("#cliente_parc").val($("#cliente").val());
+                $("#idCliente_parc").val($("#idCliente").val());
                 $("#tipo_parc").val($("#tipo").val());
                 $("#formaPgto_parc").val($("#formaPgto").val());
 				$("#pcontas_parc").val($("#pcontas").val());
@@ -1053,6 +1055,7 @@ echo number_format($soma_descontos_pagos, 2, ',', '.')?></strong></td>
 					$('#abrirmodalreceitaparcelada').trigger('click');
 					$("#descricao_parc").val($("#descricao").val());
 					$("#cliente_parc").val($("#cliente").val());
+                    $("#idCliente_parc").val($("#idCliente").val());
                     $("#tipo_parc").val($("#tipo").val());
                     $("#formaPgto_parc").val($("#formaPgto").val());
 					$("#pcontas_parc").val($("#pcontas").val());

--- a/application/views/financeiro/lancamentos.php
+++ b/application/views/financeiro/lancamentos.php
@@ -392,6 +392,7 @@ echo number_format($soma_descontos_pagos, 2, ',', '.')?></strong></td>
     		<div class="span6" style="margin-left: 0"> 
     			<label for="cliente_parc">Cliente/Fornecedor*</label>
     			<input class="span11" id="cliente_parc" type="text" name="cliente_parc" required />
+                <input class="span11" id="idCliente" type="hidden" name="idCliente" value="" />
     		</div>
 		
 			<div class="span6" style="margin-left: 0">


### PR DESCRIPTION
- Criado o envio do idCliente como hidden para ser usado na adição do lançamento.
- Removido o IF, pois o campo de idFornecedor e idCliente não é mais enviado pelo front após a adição da feature de parcelamento.

![image](https://github.com/RamonSilva20/mapos/assets/70410692/f9cbcc6a-27ef-4ed0-b529-7d0bcc338595)

- Neste caso, alimentando da forma correta, cliente_fornecedor e clientes_id como era o proposito da PR #2171 
![image](https://github.com/RamonSilva20/mapos/assets/70410692/78349108-b2e4-42cc-a83a-3d768ce821ad)


Issue relacionada: #2210 