### PR TITLE
FIX / Desconto Modal Status OS do Calendário Dash

### DIFF
--- a/application/controllers/Mapos.php
+++ b/application/controllers/Mapos.php
@@ -559,7 +559,7 @@ class Mapos extends MY_Controller
                     'observacoes' => '<b>Observações:</b> ' . strip_tags(html_entity_decode($os->observacoes)),
                     'total' => '<b>Valor Total:</b> R$ ' . number_format($os->totalProdutos + $os->totalServicos, 2, ',', '.'),
                     'desconto' => '<b>Desconto:</b> R$ ' . number_format($os->desconto, 2, ',', '.'),
-                    'valorFaturado' => '<b>Valor Faturado:</b> R$ ' . number_format($os->valorTotal - $os->desconto, 2, ',', '.'),
+                    'valorFaturado' => '<b>Valor Faturado:</b> R$ ' . number_format(($os->totalProdutos + $os->totalServicos) - $os->desconto, 2, ',', '.'),
                     'editar' => $this->os_model->isEditable($os->idOs),
                 ]
             ];


### PR DESCRIPTION
Olá Srs,
Identificado erro no calculo do Valor Faturado no modal do Status OS do Calendário do Dashboard. Segue Correção:

Antes:
![Imagem do WhatsApp de 2023-10-05 à(s) 17 32 54_c5108453](https://github.com/RamonSilva20/mapos/assets/45976190/75286c29-66fb-43a5-8c2f-525bd5a4cbcb)

Depois:
 
![Imagem do WhatsApp de 2023-10-05 à(s) 17 48 09_7974c0fb](https://github.com/RamonSilva20/mapos/assets/45976190/5cd060ee-9c9e-4f12-8d6c-06cbfa08f76d)
