### PR TITLE
Fix/Cabeçalho Faturar OS

### DIFF
--- a/application/views/os/editarOs.php
+++ b/application/views/os/editarOs.php
@@ -479,10 +479,10 @@ foreach ($servicos as $s) {
 </div>
 
 <!-- Modal Faturar-->
-<div id="modal-faturar" class="modal hide fade widget_box_vizualizar4" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+<div id="modal-faturar" class="modal hide fade " tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
     <form id="formFaturar" action="<?php echo current_url() ?>" method="post">
-        <div class="modal_header_anexos">
-            <button type="button" class="close" style="color:#f00" data-dismiss="modal" aria-hidden="true">×</button>
+        <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
             <h3 id="myModalLabel">Faturar OS</h3>
         </div>
         <div class="modal-body">


### PR DESCRIPTION
Identificado que o Cabeçalho OS se encontra com erro, feito ajuste para padronização.

Antes:
![Imagem do WhatsApp de 2023-10-05 à(s) 23 02 41_66aa25f5](https://github.com/RamonSilva20/mapos/assets/45976190/0ab3b3cb-4993-403f-b147-8a7eaed7b78b)

 Depois:
![Imagem do WhatsApp de 2023-10-05 à(s) 23 24 29_98084214](https://github.com/RamonSilva20/mapos/assets/45976190/e9fead07-4adb-445f-ab20-74d6a031814b)
