### PR TITLE
Fix Ordenação de Resultados (Área do Cliente)

### DIFF
--- a/application/models/Conecte_model.php
+++ b/application/models/Conecte_model.php
@@ -41,6 +41,7 @@ class Conecte_model extends CI_Model
         $this->db->join('usuarios', 'usuarios.idUsuarios = vendas.usuarios_id');
         $this->db->where('clientes_id', $cliente);
         $this->db->limit(5);
+        $this->db->order_by('idVendas', 'desc');
 
         return $this->db->get()->result();
     }
@@ -53,6 +54,7 @@ class Conecte_model extends CI_Model
         $this->db->join('usuarios', 'vendas.usuarios_id = usuarios.idUsuarios', 'left');
         $this->db->where('clientes_id', $cliente);
         $this->db->limit($perpage, $start);
+        $this->db->order_by('idVendas', 'desc');
         if ($where) {
             $this->db->where($where);
         }
@@ -70,6 +72,7 @@ class Conecte_model extends CI_Model
         $this->db->join('clientes', 'cobrancas.clientes_id = clientes.idClientes', 'left');
         $this->db->where('clientes_id', $cliente);
         $this->db->limit($perpage, $start);
+        $this->db->order_by('idCobrancas', 'desc');
         if ($where) {
             $this->db->where($where);
         }


### PR DESCRIPTION
Batendo um papo com o @cabralwms me relatou que a ordenação de algumas buscas da área do cliente precisavam ser ordenadas do mais recente para o mais antigo (decrescente), então realizamos o ajuste dela.

Alteração realizada para tabelas Ultimas Compras, Ultimas Ordens de Serviço, Compras e Cobranças.

Exemplo:
Ordenado do maior para o menor por padrão.
![image](https://github.com/RamonSilva20/mapos/assets/45976190/0e564a57-5474-4972-9f88-cfd051d9344b)
