### PR TITLE
Correção gerencianet para Efipay

### DIFF
--- a/application/config/payment_gateways.php
+++ b/application/config/payment_gateways.php
@@ -27,6 +27,7 @@ $config['payment_gateways'] = [
             'new' => 'Cobrança / Assinatura gerada',
             'waiting' => 'Aguardando a confirmação do pagamento',
             'paid' => 'Pagamento confirmado',
+            'identified' => 'Pagamento confirmado',
             'unpaid' => 'Não foi possível confirmar o pagamento da cobrança',
             'refunded' => 'Pagamento devolvido pelo lojista ou pelo intermediador Gerencianet',
             'contested' => 'Pagamento em processo de contestação',

--- a/application/libraries/Gateways/GerencianetSdk.php
+++ b/application/libraries/Gateways/GerencianetSdk.php
@@ -1,6 +1,6 @@
 <?php
 
-use Gerencianet\Gerencianet;
+use Efi\EfiPay;
 use Libraries\Gateways\BasePaymentGateway;
 use Libraries\Gateways\Contracts\PaymentGateway;
 
@@ -23,7 +23,7 @@ class GerencianetSdk extends BasePaymentGateway
 
         $gerenciaNetConfig = $this->ci->config->item('payment_gateways')['GerencianetSdk'];
         $this->gerenciaNetConfig = $gerenciaNetConfig;
-        $this->gerenciaNetApi = new Gerencianet([
+        $this->gerenciaNetApi = new EfiPay([
             'client_id' => $gerenciaNetConfig['credentials']['client_id'],
             'client_secret' => $gerenciaNetConfig['credentials']['client_secret'],
             'sandbox' => $gerenciaNetConfig['production'] !== true,
@@ -269,7 +269,7 @@ class GerencianetSdk extends BasePaymentGateway
             ]
         ];
 
-        $result = $this->gerenciaNetApi->oneStep([], $body);
+        $result = $this->gerenciaNetApi->createOneStepCharge([], $body);
         if (intval($result['code']) !== 200) {
             throw new \Exception('Erro ao chamar GerenciaNet!');
         }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
         "ext-curl": "*",
         "ext-gd": "*",
         "mercadopago/dx-php": "^2.2.1",
-        "gerencianet/gerencianet-sdk-php": "^2.4.1",
         "codeigniter/framework": "^3.1",
         "mpdf/mpdf": "^8.0.10",
         "filp/whoops": "^2.7",
@@ -12,7 +11,8 @@
         "mpdf/qrcode": "^1.1",
         "phpoffice/phpword": "^0.18.0",
         "piggly/php-pix": "^2.0",
-        "codephix/asaas-sdk": "dev-master"
+        "codephix/asaas-sdk": "dev-master",
+        "efipay/sdk-php-apis-efi": "^1.7.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",


### PR DESCRIPTION
Fiz a correção do api do gerencianet para Efipay, atualizando o composer e arquivos necessários para o funcionamento, corrigindo bug de data ao criar boletos para datas futuras que estava dando erro.

![image](https://github.com/RamonSilva20/mapos/assets/61280919/7de292c0-78ad-41c3-866c-aff39a5d57af)
