### PR TITLE
Ajustando nome da coluna no order by

### DIFF
--- a/application/models/Conecte_model.php
+++ b/application/models/Conecte_model.php
@@ -72,7 +72,7 @@ class Conecte_model extends CI_Model
         $this->db->join('clientes', 'cobrancas.clientes_id = clientes.idClientes', 'left');
         $this->db->where('clientes_id', $cliente);
         $this->db->limit($perpage, $start);
-        $this->db->order_by('idCobrancas', 'desc');
+        $this->db->order_by('idCobranca', 'desc');
         if ($where) {
             $this->db->where($where);
         }


### PR DESCRIPTION
Ao acessar a área de cliente e clicar em "Cobranças" está estourando um erro.
![image](https://github.com/RamonSilva20/mapos/assets/13459803/55072a8c-9e43-4704-a643-bb5428e83d99)

Verifiquei que o problema é o nome da coluna que está sendo utilizado no order_by.
![image](https://github.com/RamonSilva20/mapos/assets/13459803/3c98839a-21ea-4e8b-b248-60fb0cd3538c)

O nome correto da coluna é no singular.
![image](https://github.com/RamonSilva20/mapos/assets/13459803/5aa7882d-7c8a-4943-949e-65b1526ab3dd)

Após a alteração a página volta a carregar normalmente.
![image](https://github.com/RamonSilva20/mapos/assets/13459803/8fbae7fe-f6b3-40be-8624-25d81c3229b5)
