### PR TITLE
Adicionando Tags html de forma correta no BD

### DIFF
--- a/application/controllers/Os.php
+++ b/application/controllers/Os.php
@@ -118,11 +118,11 @@ class Os extends MY_Controller
                 'dataFinal' => $dataFinal,
                 'garantia' => set_value('garantia'),
                 'garantias_id' => $termoGarantiaId,
-                'descricaoProduto' => set_value('descricaoProduto'),
-                'defeito' => set_value('defeito'),
+                'descricaoProduto' => $this->input->post('descricaoProduto'),
+                'defeito' => $this->input->post('defeito'),
                 'status' => set_value('status'),
-                'observacoes' => set_value('observacoes'),
-                'laudoTecnico' => set_value('laudoTecnico'),
+                'observacoes' => $this->input->post('observacoes'),
+                'laudoTecnico' => $this->input->post('laudoTecnico'),
                 'faturado' => 0,
             ];
 


### PR DESCRIPTION
Ao adicionar uma OS caracteres como o "<" são inseridos como uma entidade de caractere.
![SQLyogCommunity_UqDSAIlT65](https://github.com/RamonSilva20/mapos/assets/13459803/c7846eaa-db18-4339-b259-525ffe7fa68b)

Ao editar uma OS esses mesmo caracteres são adicionados como o próprio caractere e não como uma entidade de caractere.
![SQLyogCommunity_1tBJWe44Zc](https://github.com/RamonSilva20/mapos/assets/13459803/4c8d504f-52f3-49e9-9ce7-aaddfdede267)

Ao utilizar esses dados vindo do banco de dados é necessário fazer um tratamento nele pois não se sabe como ele virá do banco de dados.
![image](https://github.com/RamonSilva20/mapos/assets/13459803/721cb331-3d4e-4d66-abac-46ec630fc985)

Envio essa PR afim de padronizar a forma como os dados são salvos no banco de dados facilitando assim o uso dessas informações.

Essa PR resolve também um problema antigo que temos no envio de mensagem pelo Whatsapp.
![image](https://github.com/RamonSilva20/mapos/assets/13459803/36c49bda-304e-4621-ac01-41ca2e9966b5)

