### PR TITLE
Cria um novo diretório no update

### DIFF
--- a/application/libraries/Github_updater.php
+++ b/application/libraries/Github_updater.php
@@ -92,6 +92,18 @@ class Github_updater
                         }
                         // Otherwise copy the file from the update.
                         else {
+                            $arrFilename = explode('/', $file->filename);
+                            if(is_array($arrFilename) && count($arrFilename) > 0) {
+                                $diretorio = '';
+                                for ($i = 0; $i < (count($arrFilename) - 1); $i++) {
+                                    $diretorio .= $arrFilename[$i].'/';
+                                }
+                                
+                                if(!file_exists($diretorio)) {
+                                    mkdir($diretorio, 0755, true);
+                                }
+                            }
+                            
                             copy($dir.'/'.$file->filename, $file->filename);
                         }
                     }


### PR DESCRIPTION
Caso no update seja adicionado um novo diretório, e o Mapos do usuário não possua esse diretório, o Github_updater cria o diretório.