### PR TITLE
Adicionando xss_clean aos textarea

### DIFF
--- a/application/controllers/Mine.php
+++ b/application/controllers/Mine.php
@@ -741,10 +741,10 @@ class Mine extends CI_Controller
                 'clientes_id' => $this->session->userdata('cliente_id'), //set_value('idCliente'),
                 'usuarios_id' => $id, //set_value('idUsuario'),
                 'dataFinal' => date('Y-m-d'),
-                'descricaoProduto' => $this->input->post('descricaoProduto'),
-                'defeito' => $this->input->post('defeito'),
+                'descricaoProduto' => $this->security->xss_clean($this->input->post('descricaoProduto')),
+                'defeito' => $this->security->xss_clean($this->input->post('defeito')),
                 'status' => 'Aberto',
-                'observacoes' => set_value('observacoes'),
+                'observacoes' => $this->security->xss_clean(set_value('observacoes')),
                 'faturado' => 0,
             ];
 


### PR DESCRIPTION
Quando o cliente tentar enviar um script JS no textarea dos campos Equipamento, Defeito e Observações
o xss_clean remove a tag <script> e adiciona a tag [removed] Evitando assim a execução de scripts inesperados.
Esse fix vem como mais um recurso para proteger o sistema de ataques como os que ocorreram recentemente em vários mapos.
![image](https://github.com/RamonSilva20/mapos/assets/13459803/f7b86d1a-c46f-400f-bda4-de1dbfa59d6c)
