### PR TITLE
Informando ao Log de qual OS o serviço foi excluido

### DIFF
--- a/application/views/os/editarOs.php
+++ b/application/views/os/editarOs.php
@@ -1138,7 +1138,6 @@ foreach ($servicos as $s) {
                     type: "POST",
                     url: "<?php echo base_url(); ?>index.php/os/excluirServico",
                     data: "idServico=" + idServico + "&idOs=" + idOS,
-                    data: "idServico=" + idServico,
                     dataType: 'json',
                     success: function(data) {
                         if (data.result == true) {


### PR DESCRIPTION
Ao excluir uma OS o Log não estava salvando de qual OS o serviço foi excluído pois o idOs não estava sendo enviado.
![image](https://github.com/RamonSilva20/mapos/assets/13459803/639e0b71-2cdd-4007-8ffa-20e8cc54917a)

Removendo essa linha o idOs passa a ser enviado e o log passa a informar a OS