### PR TITLE
Ajustes ao adicionar "riscado" em algum texto pelo editor trumbowyg

### DIFF
--- a/application/views/conecte/adicionarOs.php
+++ b/application/views/conecte/adicionarOs.php
@@ -116,7 +116,8 @@
         });
 
         $('.editor').trumbowyg({
-            lang: 'pt_br'
+            lang: 'pt_br',
+            semantic: { 'strikethrough': 's', }
         });
     });
 </script>

--- a/application/views/conecte/detalhes_os.php
+++ b/application/views/conecte/detalhes_os.php
@@ -338,7 +338,8 @@ foreach ($servicos as $s) {
 <script type="text/javascript">
     $(document).ready(function() {
         $('.editor').trumbowyg({
-            lang: 'pt_br'
+            lang: 'pt_br',
+            semantic: { 'strikethrough': 's', }
         });
     });
 

--- a/application/views/garantias/adicionarGarantia.php
+++ b/application/views/garantias/adicionarGarantia.php
@@ -117,7 +117,8 @@
             dateFormat: 'dd/mm/yy'
         });
         $('.editor').trumbowyg({
-            lang: 'pt_br'
+            lang: 'pt_br',
+            semantic: { 'strikethrough': 's', }
         });
     });
 </script>

--- a/application/views/garantias/editarGarantia.php
+++ b/application/views/garantias/editarGarantia.php
@@ -111,7 +111,8 @@
             dateFormat: 'dd/mm/yy'
         });
         $('.editor').trumbowyg({
-            lang: 'pt_br'
+            lang: 'pt_br',
+            semantic: { 'strikethrough': 's', }
         });
     });
 </script>

--- a/application/views/os/adicionarOs.php
+++ b/application/views/os/adicionarOs.php
@@ -180,7 +180,8 @@
             dateFormat: 'dd/mm/yy'
         });
         $('.editor').trumbowyg({
-            lang: 'pt_br'
+            lang: 'pt_br',
+            semantic: { 'strikethrough': 's', }
         });
     });
 </script>

--- a/application/views/os/editarOs.php
+++ b/application/views/os/editarOs.php
@@ -1229,7 +1229,8 @@ foreach ($servicos as $s) {
         });
 
         $('.editor').trumbowyg({
-            lang: 'pt_br'
+            lang: 'pt_br',
+            semantic: { 'strikethrough': 's', }
         });
     });
 </script>

--- a/application/views/vendas/adicionarVenda.php
+++ b/application/views/vendas/adicionarVenda.php
@@ -137,7 +137,8 @@
             dateFormat: 'dd/mm/yy'
         });
         $('.editor').trumbowyg({
-            lang: 'pt_br'
+            lang: 'pt_br',
+            semantic: { 'strikethrough': 's', }
         });
         $('.addclient').hide();
     });

--- a/application/views/vendas/editarVenda.php
+++ b/application/views/vendas/editarVenda.php
@@ -638,7 +638,8 @@ foreach ($produtos as $p) {
             dateFormat: 'dd/mm/yy'
         });
         $('.editor').trumbowyg({
-            lang: 'pt_br'
+            lang: 'pt_br',
+            semantic: { 'strikethrough': 's', }
         });
     });
 </script>

--- a/assets/trumbowyg/trumbowyg.js
+++ b/assets/trumbowyg/trumbowyg.js
@@ -105,7 +105,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
             ['viewHTML'],
             ['undo', 'redo'], // Only supported in Blink browsers
             ['formatting'],
-            ['strong', 'em', 'del'],
+            ['strong', 'em', 'strikethrough'],
             ['superscript', 'subscript'],
             ['link'],
             ['insertImage'],


### PR DESCRIPTION
Ao clicar para riscar um texto no editor, após desmarcar esse texto não é possível remover o riscado selecionando o mesmo texto e clicando no botão de riscado no editor.
![chrome_CF93F2pqkN](https://github.com/RamonSilva20/mapos/assets/13459803/3ee94495-dcc0-4eba-97d9-bc382d0e4722)

Com essa alteração esse bug é corrigido em todos os editores
![chrome_gMaY67Xlyx](https://github.com/RamonSilva20/mapos/assets/13459803/3b60b037-598f-4aab-a9e9-76a022944501)
