### PR TITLE
Correção do Calendário Status Aprovado

### DIFF
--- a/application/controllers/Mapos.php
+++ b/application/controllers/Mapos.php
@@ -538,6 +538,9 @@ class Mapos extends MY_Controller
                 case 'Aguardando Peças':
                     $cor = '#FF7F00';
                     break;
+                case 'Aprovado':
+                    $cor = '#808080';
+                    break;
                 default:
                     $cor = '#E0E4CC';
                     break;


### PR DESCRIPTION
Feita correção no status do calendário Aprovado que estava sem a cor padrão que está no status da OS.