### PR TITLE
Corrigindo buscas por cpf, autocomplete com cpf

### DIFF
--- a/application/models/Mapos_model.php
+++ b/application/models/Mapos_model.php
@@ -56,6 +56,7 @@ class Mapos_model extends CI_Model
         $this->db->like('nomeCliente', $termo);
         $this->db->or_like('telefone', $termo);
         $this->db->or_like('celular', $termo);
+        $this->db->or_like('documento', $termo);
         $this->db->limit(15);
         $data['clientes'] = $this->db->get('clientes')->result();
 

--- a/application/models/Os_model.php
+++ b/application/models/Os_model.php
@@ -40,6 +40,7 @@ class Os_model extends CI_Model
             if (array_key_exists('pesquisa', $where)) {
                 $this->db->select('idClientes');
                 $this->db->like('nomeCliente', $where['pesquisa']);
+                $this->db->like('documento', $where['pesquisa']);
                 $this->db->limit(25);
                 $clientes = $this->db->get('clientes')->result();
 
@@ -217,10 +218,11 @@ class Os_model extends CI_Model
         $this->db->like('nomeCliente', $q);
         $this->db->or_like('telefone', $q);
         $this->db->or_like('celular', $q);
+        $this->db->or_like('documento', $q);
         $query = $this->db->get('clientes');
         if ($query->num_rows() > 0) {
             foreach ($query->result_array() as $row) {
-                $row_set[] = ['label' => $row['nomeCliente'] . ' | Telefone: ' . $row['telefone'] . ' | Celular: ' . $row['celular'], 'id' => $row['idClientes']];
+                $row_set[] = ['label' => $row['nomeCliente'] . ' | Telefone: ' . $row['telefone'] . ' | Celular: ' . $row['celular'] . ' | Documento: ' . $row['documento'], 'id' => $row['idClientes']];
             }
             echo json_encode($row_set);
         }

--- a/application/models/Os_model.php
+++ b/application/models/Os_model.php
@@ -40,7 +40,7 @@ class Os_model extends CI_Model
             if (array_key_exists('pesquisa', $where)) {
                 $this->db->select('idClientes');
                 $this->db->like('nomeCliente', $where['pesquisa']);
-                $this->db->limit(5);
+                $this->db->limit(25);
                 $clientes = $this->db->get('clientes')->result();
 
                 foreach ($clientes as $c) {
@@ -182,7 +182,7 @@ class Os_model extends CI_Model
     public function autoCompleteProduto($q)
     {
         $this->db->select('*');
-        $this->db->limit(5);
+        $this->db->limit(25);
         $this->db->like('codDeBarra', $q);
         $this->db->or_like('descricao', $q);
         $query = $this->db->get('produtos');
@@ -197,7 +197,7 @@ class Os_model extends CI_Model
     public function autoCompleteProdutoSaida($q)
     {
         $this->db->select('*');
-        $this->db->limit(5);
+        $this->db->limit(25);
         $this->db->like('codDeBarra', $q);
         $this->db->or_like('descricao', $q);
         $this->db->where('saida', 1);
@@ -213,7 +213,7 @@ class Os_model extends CI_Model
     public function autoCompleteCliente($q)
     {
         $this->db->select('*');
-        $this->db->limit(5);
+        $this->db->limit(25);
         $this->db->like('nomeCliente', $q);
         $this->db->or_like('telefone', $q);
         $this->db->or_like('celular', $q);
@@ -229,7 +229,7 @@ class Os_model extends CI_Model
     public function autoCompleteUsuario($q)
     {
         $this->db->select('*');
-        $this->db->limit(5);
+        $this->db->limit(25);
         $this->db->like('nome', $q);
         $this->db->where('situacao', 1);
         $query = $this->db->get('usuarios');
@@ -244,7 +244,7 @@ class Os_model extends CI_Model
     public function autoCompleteTermoGarantia($q)
     {
         $this->db->select('*');
-        $this->db->limit(5);
+        $this->db->limit(25);
         $this->db->like('LOWER(refGarantia)', $q);
         $query = $this->db->get('garantias');
         if ($query->num_rows() > 0) {
@@ -258,7 +258,7 @@ class Os_model extends CI_Model
     public function autoCompleteServico($q)
     {
         $this->db->select('*');
-        $this->db->limit(5);
+        $this->db->limit(25);
         $this->db->like('nome', $q);
         $query = $this->db->get('servicos');
         if ($query->num_rows() > 0) {


### PR DESCRIPTION
Corrigindo a buscar para buscar o CPF do cliente (documento), e tambem ao cadastrar a Ordem de Serviço adicionado o CPF.

![image](https://github.com/RamonSilva20/mapos/assets/61280919/e982b6ba-3a95-4fea-b7c3-0bc175801513)


autocomplete da Ordem de Serviço 

![image](https://github.com/RamonSilva20/mapos/assets/61280919/7de4fb23-2c76-484f-a8fa-f3996d75188f)

