### PR TITLE
Padronizar dados Clientes em Vendas

### DIFF
--- a/application/views/vendas/imprimirVenda.php
+++ b/application/views/vendas/imprimirVenda.php
@@ -74,14 +74,23 @@
                                             <li>
                                                 <span>
                                                     <h5>Cliente</h5>
-                                                    <?php echo $result->nomeCliente ?> -
-                                                    <?php echo $result->documento ?></br>
-                                                    <?php echo $result->rua ?>,
-                                                    <?php echo $result->numero ?>,
-                                                    <?php echo $result->bairro ?>,
-                                                    <?php echo $result->cidade ?> -
-                                                    <?php echo $result->estado ?>
-                                                </span>
+                                                    <span>
+                                                        <?php echo $result->nomeCliente ?>
+                                                    </span><br />
+                                                    <span>
+                                                        <?php echo $result->rua ?>, <?php echo $result->numero ?>, <?php echo $result->bairro ?>
+                                                    </span><br/>
+                                                    <span>
+                                                        <?php echo $result->cidade ?> - <?php echo $result->estado ?> - CEP: <?php echo $result->cep ?>
+                                                    </span><br/>
+                                                    <span>
+                                                        Email: <?php echo $result->emailCliente ?>
+                                                    </span></br>
+                                                    <?php if ($result->contato) { ?>
+                                                        <span>Contato: <?php echo $result->contato ?> </span>
+                                                    <?php } ?>
+                                                    <span>Celular: <?php echo $result->celular ?></span>
+							                    </span>
                                             </li>
                                         </ul>
                                     </td>

--- a/application/views/vendas/imprimirVendaOrcamento.php
+++ b/application/views/vendas/imprimirVendaOrcamento.php
@@ -74,14 +74,23 @@
                                             <li>
                                                 <span>
                                                     <h5>Cliente</h5>
-                                                    <?php echo $result->nomeCliente ?> -
-                                                    <?php echo $result->documento ?></br>
-                                                    <?php echo $result->rua ?>,
-                                                    <?php echo $result->numero ?>,
-                                                    <?php echo $result->bairro ?>,
-                                                    <?php echo $result->cidade ?> -
-                                                    <?php echo $result->estado ?>
-                                                </span>
+                                                    <span>
+                                                        <?php echo $result->nomeCliente ?>
+                                                    </span><br />
+                                                    <span>
+                                                        <?php echo $result->rua ?>, <?php echo $result->numero ?>, <?php echo $result->bairro ?>
+                                                    </span><br/>
+                                                    <span>
+                                                        <?php echo $result->cidade ?> - <?php echo $result->estado ?> - CEP: <?php echo $result->cep ?>
+                                                    </span><br/>
+                                                    <span>
+                                                        Email: <?php echo $result->emailCliente ?>
+                                                    </span></br>
+                                                    <?php if ($result->contato) { ?>
+                                                        <span>Contato: <?php echo $result->contato ?> </span>
+                                                    <?php } ?>
+                                                    <span>Celular: <?php echo $result->celular ?></span>
+							                    </span>
                                             </li>
                                         </ul>
                                     </td>

--- a/application/views/vendas/visualizarVenda.php
+++ b/application/views/vendas/visualizarVenda.php
@@ -62,16 +62,22 @@
                                                 <span>
                                                     <h5>Cliente</h5>
                                                     <span>
-                                                        <?php echo $result->nomeCliente ?></span><br />
+                                                        <?php echo $result->nomeCliente ?>
+                                                    </span><br />
                                                     <span>
-                                                        <?php echo $result->rua ?>,
-                                                        <?php echo $result->numero ?>,
-                                                        <?php echo $result->bairro ?></span><br />
+                                                        <?php echo $result->rua ?>, <?php echo $result->numero ?>, <?php echo $result->bairro ?>
+                                                    </span><br/>
                                                     <span>
-                                                        <?php echo $result->cidade ?> -
-                                                        <?php echo $result->estado ?><br />
-                                                        <span>Email:
-                                                            <?php echo $result->emailCliente ?></span>
+                                                        <?php echo $result->cidade ?> - <?php echo $result->estado ?> - CEP: <?php echo $result->cep ?>
+                                                    </span><br/>
+                                                    <span>
+                                                        Email: <?php echo $result->emailCliente ?>
+                                                    </span></br>
+                                                    <?php if ($result->contato) { ?>
+                                                        <span>Contato: <?php echo $result->contato ?> </span>
+                                                    <?php } ?>
+                                                    <span>Celular: <?php echo $result->celular ?></span>
+							                    </span>
                                             </li>
                                         </ul>
                                     </td>


### PR DESCRIPTION
Feita uma correção no setor de vendas para manter padronizado como aparece nas ordens de Serviços, as mesmas informações em vendas, no vizualizar vendas, imprimir vendas, imprimir orçamento vendas.



Antes da modificação

![image](https://github.com/RamonSilva20/mapos/assets/61280919/b7265461-0c2a-48cb-98a2-6d694664b18e)

Após modificar

![image](https://github.com/RamonSilva20/mapos/assets/61280919/52f9ea41-5774-4998-8a4c-cb52a82710d8)

imprimir vendas antes da modificação

![image](https://github.com/RamonSilva20/mapos/assets/61280919/37d718c6-ab6b-4392-ab37-e17d5b3e1bb6)

ao Imprimir vendas modificado

![image](https://github.com/RamonSilva20/mapos/assets/61280919/b6b8fc30-2adf-497c-b4eb-05ccce206479)

orçamentos antes da modificação

![image](https://github.com/RamonSilva20/mapos/assets/61280919/7243cf8f-47b6-47e1-9d7b-4cf3e3fb557e)

ao imprimir vendas orçamentos

![image](https://github.com/RamonSilva20/mapos/assets/61280919/6e6d940a-b948-4eb5-8867-ac5736568544)
