### PR TITLE
Só trata data de pagamento se a mesma for informada

### DIFF
--- a/application/controllers/Financeiro.php
+++ b/application/controllers/Financeiro.php
@@ -471,7 +471,7 @@ class Financeiro extends MY_Controller
                 $vencimento = explode('/', $vencimento);
                 $vencimento = $vencimento[2] . '-' . $vencimento[1] . '-' . $vencimento[0];
 
-                if($pagamento) {
+                if ($pagamento) {
                     $pagamento = explode('/', $pagamento);
                     $pagamento = $pagamento[2] . '-' . $pagamento[1] . '-' . $pagamento[0];
                 }

--- a/application/controllers/Financeiro.php
+++ b/application/controllers/Financeiro.php
@@ -471,8 +471,10 @@ class Financeiro extends MY_Controller
                 $vencimento = explode('/', $vencimento);
                 $vencimento = $vencimento[2] . '-' . $vencimento[1] . '-' . $vencimento[0];
 
-                $pagamento = explode('/', $pagamento);
-                $pagamento = $pagamento[2] . '-' . $pagamento[1] . '-' . $pagamento[0];
+                if($pagamento) {
+                    $pagamento = explode('/', $pagamento);
+                    $pagamento = $pagamento[2] . '-' . $pagamento[1] . '-' . $pagamento[0];
+                }
             } catch (Exception $e) {
                 $vencimento = date('Y/m/d');
             }


### PR DESCRIPTION
Ao editar um lançamento que ainda não foi pago o sistema tentava fazer o tratamento, como o campo estava vazio dava erro ao fazer o update.
![image](https://github.com/RamonSilva20/mapos/assets/13459803/cdaa5b1b-f544-470c-8f07-b527ebd78c38)

Com essa correção, se uma data de pagamento não for informada o sistema não tentará tratar a mesma e o erro não ocorrerá mais.