### PR TITLE
Correção sobreposição na os

### DIFF
--- a/application/models/Os_model.php
+++ b/application/models/Os_model.php
@@ -228,7 +228,6 @@ class Os_model extends CI_Model
         $this->db->select('*');
         $this->db->limit(25);
         $this->db->like('nome', $q);
-        $this->db->or_like('documento', $q);
         $this->db->where('situacao', 1);
         $query = $this->db->get('usuarios');
         if ($query->num_rows() > 0) {

--- a/application/models/Os_model.php
+++ b/application/models/Os_model.php
@@ -34,7 +34,7 @@ class Os_model extends CI_Model
             if (array_key_exists('pesquisa', $where)) {
                 $this->db->select('idClientes');
                 $this->db->like('nomeCliente', $where['pesquisa']);
-                $this->db->like('documento', $where['pesquisa']);
+                $this->db->or_like('documento', $where['pesquisa']);
                 $this->db->limit(25);
                 $clientes = $this->db->get('clientes')->result();
 
@@ -228,6 +228,7 @@ class Os_model extends CI_Model
         $this->db->select('*');
         $this->db->limit(25);
         $this->db->like('nome', $q);
+        $this->db->or_like('documento', $q);
         $this->db->where('situacao', 1);
         $query = $this->db->get('usuarios');
         if ($query->num_rows() > 0) {

--- a/application/views/os/adicionarOs.php
+++ b/application/views/os/adicionarOs.php
@@ -7,6 +7,7 @@
 <script type="text/javascript" src="<?php echo base_url() ?>assets/trumbowyg/langs/pt_br.js"></script>
 
 <link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/custom.css" />
+
 <style>
     .ui-menu {
         z-index: 9999 !important;

--- a/application/views/os/adicionarOs.php
+++ b/application/views/os/adicionarOs.php
@@ -7,6 +7,11 @@
 <script type="text/javascript" src="<?php echo base_url() ?>assets/trumbowyg/langs/pt_br.js"></script>
 
 <link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/custom.css" />
+<style>
+    .ui-menu {
+        z-index: 9999 !important;
+    }
+</style>
 
 <div class="row-fluid" style="margin-top:0">
     <div class="span12">

--- a/application/views/os/editarOs.php
+++ b/application/views/os/editarOs.php
@@ -8,6 +8,12 @@
 
 <link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/custom.css" />
 
+<style>
+    .ui-menu {
+        z-index: 9999 !important;
+    }
+</style>
+
 <div class="row-fluid" style="margin-top:0">
     <div class="span12">
         <div class="widget-box">


### PR DESCRIPTION
Feita uma correção no menu auto complete em Adicionar OS, e Editar OS, aonde os campos nome do cliente e nome do tecnico, quando tem um menu grande ficava bugado.

Antes da modificação.

![image](https://github.com/RamonSilva20/mapos/assets/61280919/d30c6dcc-0368-4c6b-96f3-7c8bd2406a44)


Após Correção.

![image](https://github.com/RamonSilva20/mapos/assets/61280919/fb800aef-c4a7-4232-8d63-415a2603ffde)
