### PR TITLE
fix: ajusdato seed de Configuracoes

### DIFF
--- a/application/database/seeds/Configuracoes.php
+++ b/application/database/seeds/Configuracoes.php
@@ -61,6 +61,21 @@ class Configuracoes extends Seeder
                 'config' => 'pix_key',
                 'valor' => '',
             ],
+            [
+                'idConfig' => 12,
+                'config' => 'os_status_list',
+                'valor' => '[\"Aberto\",\"Faturado\",\"Negocia\\u00e7\\u00e3o\",\"Em Andamento\",\"Or\\u00e7amento\",\"Finalizado\",\"Cancelado\",\"Aguardando Pe\\u00e7as\"]',
+            ],
+            [
+                'idConfig' => 13,
+                'config' => 'control_edit_vendas',
+                'valor' => '1',
+            ],
+            [
+                'idConfig' => 15,
+                'config' => 'control_2vias',
+                'valor' => '0',
+            ],
         ];
 
         foreach ($configs as $config) {


### PR DESCRIPTION
Foi adicionado as configurações de 'os_status_list', 'control_edit_vendas' e de 'control_2vias', ambas se se encontravam, nas migrates porém, não estavam atualizadas nesse local.

![image](https://github.com/RamonSilva20/mapos/assets/169362999/936bd4bd-d151-43b0-9ecb-e006db94c56e)
