### PR TITLE
[patch] fix: adicionado codeowners, guia de contribuicao e arquitetura

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,5 @@
+# Banco de dados
+
+# Back-end
+
+# Front-end

--- a/CODEOWNERS.md
+++ b/CODEOWNERS.md
@@ -1,0 +1,4 @@
+# Saiba como adicionar proprietários de código aqui:
+# https://help.github.com/en/articles/about-code-owners 
+
+*  @Pr3d4dor

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contribuindo
+
+Ao contribuir para este repositório, primeiro discuta a alteração que deseja fazer por meio de problema, e-mail ou qualquer outro método com os proprietários deste repositório antes de fazer uma alteração.
+
+Observe que temos um código de conduta, siga-o em todas as suas interações com o projeto.
+
+## Processo de solicitação pull request
+
+1. Certifique-se de que todas as dependências de instalação ou compilação sejam removidas antes do final da camada ao fazer uma compilação.
+2. Atualize o README.md, a wiki ou o ARCHITECTURE.md com detalhes de alterações na interface, incluindo novas variáveis ​​de ambiente, portas expostas, locais de arquivos úteis e parâmetros de contêiner.
+3. Aumente os números de versão em quaisquer arquivos de exemplo e README.md para a nova versão que esta solicitação pull representaria. O esquema de versionamento que usamos é [Sem Ver](http://semver.org/).
+4. Você pode mesclar a solicitação pull assim que tiver a aprovação de um ou dois outros desenvolvedores ou, se não tiver permissão para fazer isso, poderá solicitar ao segundo revisor que a mescle para você.
+
+## Código de Conduta
+
+### Nosso compromisso
+
+No interesse de promover um ambiente aberto e acolhedor, nós, como colaboradores e mantenedores, comprometemo-nos a tornar a participação no nosso projeto e na nossa comunidade uma experiência livre de assédio para todos, independentemente da idade, tamanho corporal, deficiência, etnia, identidade e expressão de género, nível de experiência, nacionalidade, aparência pessoal, raça, religião ou identidade e orientação sexual.
+
+### Our Standards
+
+Exemplos de comportamento que contribuem para a criação de um ambiente positivo incluem:
+
+* Usando uma linguagem acolhedora e inclusiva
+* Ser respeitoso com diferentes pontos de vista e experiências
+* Aceitando graciosamente críticas construtivas
+* Foco no que é melhor para a comunidade
+* Mostrar empatia para com outros membros da comunidade
+
+Exemplos de comportamento inaceitável por parte dos participantes incluem:
+
+* O uso de linguagem ou imagens sexualizadas e atenção ou avanços sexuais indesejados
+* Trolling, comentários insultuosos/depreciativos e ataques pessoais ou políticos
+* Assédio público ou privado
+* Publicar informações privadas de terceiros, como endereços físicos ou eletrônicos, sem permissão explícita
+* Outra conduta que poderia razoavelmente ser considerada inadequada em um ambiente profissional
+
+### Our Responsibilities
+
+Os mantenedores do projeto são responsáveis ​​por esclarecer os padrões de comportamento aceitável e espera-se que tomem medidas corretivas apropriadas e justas em resposta a quaisquer casos de comportamento inaceitável.
+
+Os mantenedores do projeto têm o direito e a responsabilidade de remover, editar ou rejeitar comentários, commits, códigos, edições de wiki, problemas e outras contribuições que não estejam alinhadas com este Código de Conduta, ou de banir temporária ou permanentemente qualquer contribuidor por outros comportamentos que eles considerem inadequados, ameaçadores, ofensivos ou prejudiciais.
+
+### Escopo
+
+Este Código de Conduta se aplica tanto nos espaços do projeto quanto nos espaços públicos quando um indivíduo representa o projeto ou sua comunidade. Exemplos de representação de um projeto ou comunidade incluem usar um endereço de e-mail oficial do projeto, postar através de uma conta oficial de mídia social ou atuar como representante nomeado em um evento online ou offline. A representação de um projeto pode ser definida e esclarecida pelos mantenedores do projeto.
+
+### Aplicação
+
+Instâncias de comportamento abusivo, de assédio ou de outra forma inaceitável podem ser relatadas entrando em contato com a equipe do projeto em [INSERIR ENDEREÇO ​​DE E-MAIL]. Todas as reclamações serão analisadas e investigadas e resultarão numa resposta considerada necessária e adequada às circunstâncias. A equipe do projeto é obrigada a manter a confidencialidade em relação ao relator de um incidente. Mais detalhes sobre políticas de aplicação específicas podem ser publicados separadamente.
+
+Os mantenedores do projeto que não seguirem ou não aplicarem o Código de Conduta de boa fé poderão enfrentar repercussões temporárias ou permanentes, conforme determinado por outros membros da liderança do projeto.
+
+### Atribuição
+
+Este Código de Conduta é adaptado do [Contributor Covenant][homepage],
+versão 1.4, disponível em [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/


### PR DESCRIPTION
---
name: Enhancement request
about: Sugestão de mapeamento de Arquitetura, criação de um guia de contribuição e adicionar um codeowner (representante)
---

Atualmente não existe nenhuma proposta de melhoria nesse sentido

**Por que isso é necessário**:
Eu preciso que seja adicionado um guia de contríbuição, para que existe uma forma padronizada para a abertura de 
solicitações, discuções e tomadas de descisão referente ao que será desenvolvido ou melhorado no projeto além de 
precisarmos do mapeamento Arquitetura como as dependencias do projeto.

**Sua solicitação de melhoria está relacionada a um problema? Por favor descreva.**
Hoje, o canal de comunicação de quem chega é o "issues", por algum emoção negativa (supondo: medo de não ser respondido) o que acaba misturando o que é foco: correções, melhorias e novidades; 
O não mapeamento do básico da arquitetura pode acarretar em ferramentas depreciadas, vulnerabilidades no sistema, a falta de clareza nos objetivos do projeto e durabilidade de vida do mesmo.