### PR TITLE
Removido email do técnico da mensagem

### DIFF
--- a/application/views/os/emails/os.php
+++ b/application/views/os/emails/os.php
@@ -141,8 +141,7 @@ $totalProdutos = 0; ?>
                                 <?= $emitente->nome; ?> <br>
                                 <?= $emitente->rua ?>, <?= $emitente->numero ?>, <?= $emitente->bairro ?><br>
                                 <?= $emitente->cidade ?> - <?= $emitente->uf ?> CEP: <?= $emitente->cep ?> <br>
-                                Responsável: <?= $result->nome ?><br>
-                                <?= $result->email_usuario ?>
+                                Responsável: <?= $result->nome ?>
                             </td>
                         </tr>
                     </table>


### PR DESCRIPTION
A Issue [2418](https://github.com/RamonSilva20/mapos/issues/2418) fez muito sentido.
O cliente final não deve ter o email do técnico, caso precise enviar alguma mensagem que faça para a loja/oficina.
Sem falar da questão de segurança, já que é o mesmo email utilizado no login.

Removido o email do responsável da mensagem.