### PR TITLE
Usando $_SERVER["HTTP_AUTHORIZATION"] para o App autenticar no mapos na rede local

### DIFF
--- a/application/config/jwt.php
+++ b/application/config/jwt.php
@@ -18,13 +18,6 @@ $config['jwt_algorithm'] = 'HS256';
 
 /*
 |-----------------------
-| Token Request Header Name
-|--------------------------------------------------------------------------
-*/
-$config['token_header'] = 'Authorization';
-
-/*
-|-----------------------
 | Token Expire Time
 
 | https://www.tools4noobs.com/online_tools/hh_mm_ss_to_seconds/

--- a/application/libraries/REST_Controller.php
+++ b/application/libraries/REST_Controller.php
@@ -2199,7 +2199,7 @@ abstract class REST_Controller extends CI_Controller
         $this->CI->load->config('jwt');
         $token_header = $this->CI->config->item('token_header');
 
-        if (! isset($headers[$token_header])) {
+        if (! isset($_SERVER["HTTP_AUTHORIZATION"])) {
             $this->response([
                 'status' => false,
                 'message' => 'Faça login para acessar a API.',
@@ -2208,7 +2208,7 @@ abstract class REST_Controller extends CI_Controller
         }
 
         $this->load->library('Authorization_Token');
-        $token = explode(' ', $headers[$token_header]);
+        $token = explode(' ', $_SERVER["HTTP_AUTHORIZATION"]);
         $decodedToken = (object) $this->authorization_token->validateToken($token[1]);
 
         if (! $reGenToken && ! $decodedToken->status) {


### PR DESCRIPTION
Com essa alteração a Api vai passar a aceitar autenticação mesmo que esteja hospedado no windows em rede local.

Foi preciso remover a possibilidade do usuário escolher o nome do Token Request Header.