### PR TITLE
Correção faturar vendas

### DIFF
--- a/application/controllers/Vendas.php
+++ b/application/controllers/Vendas.php
@@ -539,9 +539,6 @@ class Vendas extends MY_Controller
 
                 $this->db->set('faturado', 1);
                 $this->db->set('valorTotal', $this->input->post('valor'));
-                $this->db->where('idVendas', $venda);
-                $this->db->update('vendas');
-                
                 $this->db->set('status', 'Faturado');
                 $this->db->where('idVendas', $venda_id);
                 $this->db->update('vendas');

--- a/application/controllers/Vendas.php
+++ b/application/controllers/Vendas.php
@@ -542,6 +542,11 @@ class Vendas extends MY_Controller
                 $this->db->where('idVendas', $venda);
                 $this->db->update('vendas');
 
+                 // Atualizar o status da venda para "Faturado"
+                $this->db->set('status', 'Faturado');
+                $this->db->where('idVendas', $venda_id);
+                $this->db->update('vendas');
+
                 log_info('Faturou uma venda.');
 
                 $this->session->set_flashdata('success', 'Venda faturada com sucesso!');

--- a/application/controllers/Vendas.php
+++ b/application/controllers/Vendas.php
@@ -541,8 +541,7 @@ class Vendas extends MY_Controller
                 $this->db->set('valorTotal', $this->input->post('valor'));
                 $this->db->where('idVendas', $venda);
                 $this->db->update('vendas');
-
-                 // Atualizar o status da venda para "Faturado"
+                
                 $this->db->set('status', 'Faturado');
                 $this->db->where('idVendas', $venda_id);
                 $this->db->update('vendas');


### PR DESCRIPTION
Com essa correção ao faturar as vendas, o status do banco será atualizado colocando como faturado, coisa que não estava acontecendo.

![image](https://github.com/RamonSilva20/mapos/assets/61280919/ae4b1e66-b059-46f8-a35d-9a13cccde850)
