### PR TITLE
Melhorias e correções em visualizar os, imprimir os e views os 

### DIFF
--- a/application/controllers/Vendas.php
+++ b/application/controllers/Vendas.php
@@ -542,6 +542,11 @@ class Vendas extends MY_Controller
                 $this->db->where('idVendas', $venda);
                 $this->db->update('vendas');
 
+                 // Atualizar o status da venda para "Faturado"
+                $this->db->set('status', 'Faturado');
+                $this->db->where('idVendas', $venda_id);
+                $this->db->update('vendas');
+
                 log_info('Faturou uma venda.');
 
                 $this->session->set_flashdata('success', 'Venda faturada com sucesso!');

--- a/application/controllers/Vendas.php
+++ b/application/controllers/Vendas.php
@@ -543,16 +543,6 @@ class Vendas extends MY_Controller
                 $this->db->where('idVendas', $venda_id);
                 $this->db->update('vendas');
 
-                 // Atualizar o status da venda para "Faturado"
-                $this->db->set('status', 'Faturado');
-                $this->db->where('idVendas', $venda_id);
-                $this->db->update('vendas');
-
-                 // Atualizar o status da venda para "Faturado"
-                $this->db->set('status', 'Faturado');
-                $this->db->where('idVendas', $venda_id);
-                $this->db->update('vendas');
-
                 log_info('Faturou uma venda.');
 
                 $this->session->set_flashdata('success', 'Venda faturada com sucesso!');

--- a/application/views/os/imprimirOs.php
+++ b/application/views/os/imprimirOs.php
@@ -132,7 +132,7 @@ $totalProdutos = 0; ?>
                                                         </li>
                                                     </ul>
                                                 </td>
-                                                <?php if (in_array($result->status, ['Finalizado', 'Orçamento', 'Faturado']) && $qrCode): ?>
+                                                <?php if (in_array($result->status, ['Finalizado', 'Orçamento', 'Faturado', 'Aberto', 'Em Andamento', 'Aguardando Peças']) && $qrCode): ?>
                                                     <td style="width: 25%; padding: 0; text-align: center;">
                                                         <img style="margin: 12px 0 0 0;" src="<?= base_url(); ?>assets/img/logo_pix.png" width="64px" alt="QR Code de Pagamento" /><br>
                                                         <img style="margin: 5px 0 0 0;" width="94px" src="<?= $qrCode ?>" alt="QR Code de Pagamento" /><br>
@@ -168,7 +168,7 @@ $totalProdutos = 0; ?>
                                                     <?php endif; ?>
                                                     <td>
                                                         <b>
-                                                            <?php if (in_array($result->status, ['Finalizado', 'Faturado', 'Orçamento'])): ?>
+                                                            <?php if (in_array($result->status, ['Finalizado', 'Faturado', 'Orçamento', 'Aberto', 'Em Andamento', 'Aguardando Peças'])): ?>
                                                                 VENC. DA GARANTIA:
                                                         </b>
                                                             <?= dateInterval($result->dataFinal, $result->garantia); ?>

--- a/application/views/os/imprimirOs.php
+++ b/application/views/os/imprimirOs.php
@@ -132,15 +132,13 @@ $totalProdutos = 0; ?>
                                                         </li>
                                                     </ul>
                                                 </td>
-                                                <?php if ($result->status == 'Finalizado' || $result->status == 'Orçamento') { ?>
-                                                    <?php if ($qrCode) : ?>
-                                                        <td style="width: 25%; padding: 0;text-align:center;">
-                                                            <img style="margin:12px 0px 0px 0px" src="<?php echo base_url(); ?>assets/img/logo_pix.png" width="64px" alt="QR Code de Pagamento" /></br>
-                                                            <img style="margin:5px 0px 0px 0px" width="94px" src="<?= $qrCode ?>" alt="QR Code de Pagamento" /></br>
-                                                            <?php echo '<span style="margin:0px;font-size: 80%;text-align:center;">Chave PIX: ' . $chaveFormatada . '</span>' ;?>
-                                                        </td>
-                                                    <?php endif ?>
-                                                <?php } ?>
+                                                <?php if (in_array($result->status, ['Finalizado', 'Orçamento', 'Faturado']) && $qrCode): ?>
+                                                    <td style="width: 25%; padding: 0; text-align: center;">
+                                                        <img style="margin: 12px 0 0 0;" src="<?= base_url(); ?>assets/img/logo_pix.png" width="64px" alt="QR Code de Pagamento" /><br>
+                                                        <img style="margin: 5px 0 0 0;" width="94px" src="<?= $qrCode ?>" alt="QR Code de Pagamento" /><br>
+                                                        <span style="margin: 0; font-size: 80%; text-align: center;">Chave PIX: <?= $chaveFormatada ?></span>
+                                                    </td>
+                                                <?php endif; ?>
                                             </tr>
                                         </tbody>
                                     </table>
@@ -148,36 +146,40 @@ $totalProdutos = 0; ?>
                                 <div style="margin-top: 0; padding-top: 0">
                                     <table class="table table-condensed">
                                         <tbody>
-                                            <?php if ($result->dataInicial != null) { ?>
+                                            <?php if ($result->dataInicial != null): ?>
                                                 <tr>
                                                     <td>
                                                         <b>STATUS OS: </b>
-                                                        <?php echo $result->status ?>
+                                                        <?= $result->status ?>
                                                     </td>
                                                     <td>
                                                         <b>DATA INICIAL: </b>
-                                                        <?php echo date('d/m/Y', strtotime($result->dataInicial)); ?>
+                                                            <?= date('d/m/Y', strtotime($result->dataInicial)); ?>
                                                     </td>
                                                     <td>
                                                         <b>DATA FINAL: </b>
-                                                        <?php echo $result->dataFinal ? date('d/m/Y', strtotime($result->dataFinal)) : ''; ?>
+                                                            <?= $result->dataFinal ? date('d/m/Y', strtotime($result->dataFinal)) : ''; ?>
                                                     </td>
-                                                    <?php if ($result->garantia) {
-                                                        ?>
-                                                        <td>
-                                                            <b>GARANTIA: </b>
-                                                            <?php echo $result->garantia . ' dia(s)'; ?>
-                                                        </td>
-                                                    <?php
-                                                    } ?>
+                                                        <?php if ($result->garantia): ?>
+                                                    <td>
+                                                        <b>GARANTIA: </b>
+                                                        <?= $result->garantia . ' dia(s)'; ?>
+                                                    </td>
+                                                    <?php endif; ?>
                                                     <td>
                                                         <b>
-                                                            <?php if ($result->status == 'Finalizado') { ?>
+                                                            <?php if (in_array($result->status, ['Finalizado', 'Faturado', 'Orçamento'])): ?>
                                                                 VENC. DA GARANTIA:
                                                         </b>
-                                                        <?php echo dateInterval($result->dataFinal, $result->garantia); ?><?php } ?>
-                                                </tr>
-                                            <?php } ?>
+                                                            <?= dateInterval($result->dataFinal, $result->garantia); ?>
+                                                            <?php endif; ?>
+                                                    </td>
+                                                    </tr>
+                                            <?php endif; ?>
+                                        </tbody>
+                                    </table>
+                                </div>
+
                                             <?php if ($result->descricaoProduto != null) { ?>
                                                 <tr>
                                                     <td colspan="5">

--- a/application/views/os/os.php
+++ b/application/views/os/os.php
@@ -164,6 +164,8 @@
 
                                 if ($this->permission->checkPermission($this->session->userdata('permissao'), 'vOs')) {
                                     echo '<a style="margin-right: 1%" href="' . base_url() . 'index.php/os/visualizar/' . $r->idOs . '" class="btn-nwe" title="Ver mais detalhes"><i class="bx bx-show"></i></a>';
+                                    echo '<a style="margin-right: 1%" href="' . base_url() . 'index.php/os/imprimir/' . $r->idOs . '" target="_blank" class="btn-nwe6" title="Imprimir A4"><i class="bx bx-printer bx-xs"></i></a>';
+                                    echo '<a style="margin-right: 1%" href="' . base_url() . 'index.php/os/imprimirTermica/' . $r->idOs . '" target="_blank" class="btn-nwe6" title="Imprimir Não Fiscal"><i class="bx bx-printer bx-xs"></i></a>';
                                 }
                                 if ($editavel) {
                                     echo '<a style="margin-right: 1%" href="' . base_url() . 'index.php/os/editar/' . $r->idOs . '" class="btn-nwe3" title="Editar OS"><i class="bx bx-edit"></i></a>';

--- a/application/views/os/visualizarOs.php
+++ b/application/views/os/visualizarOs.php
@@ -143,11 +143,12 @@
                                             <?php } ?>
                                         </td>
 
-                                        <td>
-                                            <?php if ($result->status == 'Finalizado') { ?>
-                                                <b>VENC. DA GARANTIA:</b><?php echo dateInterval($result->dataFinal, $result->garantia); ?>
-                                            <?php } ?>
-                                        </td>
+                                        <?php if (in_array($result->status, ['Finalizado', 'Faturado', 'Orçamento'])): ?>
+                                            <td>
+                                                <b>VENC. DA GARANTIA:</b>
+                                                    <?= dateInterval($result->dataFinal, $result->garantia); ?>
+                                            </td>
+                                       <?php endif; ?>
                                     </tr>
                                 <?php } ?>
 

--- a/application/views/os/visualizarOs.php
+++ b/application/views/os/visualizarOs.php
@@ -143,7 +143,7 @@
                                             <?php } ?>
                                         </td>
 
-                                        <?php if (in_array($result->status, ['Finalizado', 'Faturado', 'Orçamento'])): ?>
+                                        <?php if (in_array($result->status, ['Finalizado', 'Faturado', 'Orçamento', 'Aberto'])): ?>
                                             <td>
                                                 <b>VENC. DA GARANTIA:</b>
                                                     <?= dateInterval($result->dataFinal, $result->garantia); ?>


### PR DESCRIPTION
Conforme conversado no grupo do Whatsapp fiz as melhorias e correções para Ordens de Serviços. 

Colocando para aparecer em Visualizar OS, Imprimir OS, a data com vencimento da garantia deixando claro para o cliente quando vence a sua garantia aparecendo para os Status Orçamento, finalizado e faturado. Tambem melhorias no código.

![image](https://github.com/RamonSilva20/mapos/assets/61280919/1aa56ed3-1c70-4bea-8090-6efddf8b4692)

Quando clicar em OS já ter as opções em ações de imprimir OS e Imprimir Térmica sem precisar abrir a Os para conseguir fazer isso.

![image](https://github.com/RamonSilva20/mapos/assets/61280919/a94d7293-74ed-40e6-b1a0-6a2e62157734)




