### PR TITLE
Fix correção em calculo de margem dos produtos

### DIFF
--- a/application/views/produtos/adicionarProduto.php
+++ b/application/views/produtos/adicionarProduto.php
@@ -112,7 +112,7 @@
 <script src="<?php echo base_url(); ?>assets/js/maskmoney.js"></script>
 <script type="text/javascript">
     function calcLucro(precoCompra, margemLucro) {
-        var precoVenda = (precoCompra * margemLucro / 100 + precoCompra).toFixed(2);
+        var precoVenda = (precoCompra / (100 - margemLucro)*100).toFixed(2);
         return precoVenda;
     }
     $("#precoCompra").focusout(function() {

--- a/application/views/produtos/editarProduto.php
+++ b/application/views/produtos/editarProduto.php
@@ -126,7 +126,7 @@
 <script src="<?php echo base_url(); ?>assets/js/maskmoney.js"></script>
 <script type="text/javascript">
     function calcLucro(precoCompra, margemLucro) {
-    var precoVenda = (precoCompra * margemLucro / 100 + precoCompra).toFixed(2);
+    var precoVenda = (precoCompra / (100 - margemLucro)*100).toFixed(2);
     return precoVenda;
 
 }


### PR DESCRIPTION
Atualmente na criação e edição do produto, no calculo de margem, o Map-Os pega-se o valor de compra e soma o valor da porcentagem desejada ao custo, dando incoerência, como o mostrado nos prints abaixo.

Para se ter 30 % de margem em um produto que custa R$10,00, o calculo, deveria ser

Preço Custo / ( 100 - Margem ) *100
![image](https://github.com/RamonSilva20/mapos/assets/70410692/c42afcd2-9a9a-4aea-9162-2f25923ab4e6)

Pois, 30% de 13, não é R$10, e sim R$9,1

![image](https://github.com/RamonSilva20/mapos/assets/70410692/5c4152cc-0d3a-42a5-ba67-7578d02ae4a2)

Alterando para o calculo desta PR, temos o valor correto. 

Preço custo / (100 - Margem) passando a ser:
10 / (100 - 30)
10 / 0,7
0,1428 * 100
R$14,28 -> Valor correto
![image](https://github.com/RamonSilva20/mapos/assets/70410692/eb51e0c9-c321-4669-a7b0-5b57e0f60593)

Fazendo a operação contraria, R$14,28 - 30%, terá o valor correto de R$10,00 do custo do produto.

![image](https://github.com/RamonSilva20/mapos/assets/70410692/f60284b5-5b4d-4c58-9ebf-66c69467f36b)
