### PR TITLE
Fix os id on lancamentos

### DIFF
--- a/application/controllers/Os.php
+++ b/application/controllers/Os.php
@@ -1037,6 +1037,7 @@ class Os extends MY_Controller
                 'tipo' => $this->input->post('tipo'),
                 'observacoes' => set_value('observacoes'),
                 'usuarios_id' => $this->session->userdata('id_admin'),
+                'os_id' => $os->idOs,
             ];
 
             $editavel = $this->os_model->isEditable($this->input->post('idOs'));

--- a/application/database/migrations/20240706173856_add_os_id_to_lancamentos_table.php
+++ b/application/database/migrations/20240706173856_add_os_id_to_lancamentos_table.php
@@ -1,0 +1,27 @@
+<?php
+
+class Migration_add_os_id_to_lancamentos_table extends CI_Migration
+{
+    public function up()
+    {
+        $this->dbforge->add_column('lancamentos', [
+            'os_id' => [
+                'type' => 'INT',
+                'constraint' => 11,
+                'null' => true
+            ]
+        ]);
+
+        $this->db->query('ALTER TABLE  `os` ADD CONSTRAINT `fk_os_lancamentos1`
+			FOREIGN KEY (`lancamento`)
+			REFERENCES `lancamentos` (`idLancamentos`)
+			ON DELETE NO ACTION
+			ON UPDATE NO ACTION
+		');
+    }
+
+    public function down()
+    {
+        $this->dbforge->drop_column('lancamentos', 'os_id');
+    }
+}


### PR DESCRIPTION
Ao faturar uma Os, foi identificado que na tabela lancamentos não há vinculo com a Os, assim como tem com a vendas pelo campo vendas_id.
Esse commit introduz uma nova migration para a adicao dessa coluna nova e chave estrangeira na tabela de Os
como tambem, faz a alteracao no controller da Os, para que ao faturar a mesma, seja enviado o id da Os em questao.