### PR TITLE
OS - Agrupamento Botão Imprimir

### DIFF
--- a/application/views/os/editarOs.php
+++ b/application/views/os/editarOs.php
@@ -12,22 +12,35 @@
     <div class="span12">
         <div class="widget-box">
             <div class="widget-title" style="margin: -20px 0 0">
-                <span class="icon">
-                    <i class="fas fa-diagnoses"></i>
-                </span>
+                <span class="icon"><i class="fas fa-diagnoses"></i></span>
                 <h5>Editar Ordem de Serviço</h5>
                 <div class="buttons">
                     <?php if ($result->faturado == 0) { ?>
                         <a href="#modal-faturar" id="btn-faturar" role="button" data-toggle="modal" class="button btn btn-mini btn-danger">
-                            <span class="button__icon"><i class='bx bx-dollar'></i></span> <span class="button__text">Faturar</span></a>
-                    <?php
-                    } ?>
+                            <span class="button__icon"><i class='bx bx-dollar'></i></span> <span class="button__text">Faturar</span>
+                        </a>
+                    <?php } ?>
                     <a title="Visualizar OS" class="button btn btn-primary" href="<?php echo site_url() ?>/os/visualizar/<?php echo $result->idOs; ?>">
-                        <span class="button__icon"><i class="bx bx-show"></i></span><span class="button__text">Visualizar OS</span></a>
-                    <a target="_blank" title="Imprimir OS Papel A4" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/os/imprimir/<?php echo $result->idOs; ?>">
-                        <span class="button__icon"><i class="bx bx-printer"></i></span> <span class="button__text">Papel A4</span></a>
-                    <a target="_blank" title="Imprimir OS Cupom Não Fiscal" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/os/imprimirTermica/<?php echo $result->idOs; ?>">
-                        <span class="button__icon"><i class="bx bx-printer"></i></span> <span class="button__text">CP Não Fiscal</span></a>
+                        <span class="button__icon"><i class="bx bx-show"></i></span><span class="button__text">Visualizar OS</span>
+                    </a>
+                    <div class="button-container">
+                        <a target="_blank" title="Imprimir Ordem de Serviço" class="button btn btn-mini btn-inverse">
+                            <span class="button__icon"><i class="bx bx-printer"></i></span><span class="button__text">Imprimir</span>
+                        </a>
+                        <div class="cascading-buttons">
+                            <a target="_blank" title="Impressão em Ofício A4" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/os/imprimir/<?php echo $result->idOs; ?>">
+                                <span class="button__icon"><i class='bx bx-file'></i></span> <span class="button__text">Ofício A4</span>
+                            </a>
+                            <a target="_blank" title="Impressão Cupom Não Fical" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/os/imprimirTermica/<?php echo $result->idOs; ?>">
+                                <span class="button__icon"><i class='bx bx-receipt'></i></span> <span class="button__text">Cupom 80mm</span>
+                            </a>
+                            <?php if ($result->garantias_id) { ?>
+                                <a target="_blank" title="Imprimir Termo de Garantia" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/garantias/imprimirGarantiaOs/<?php echo $result->garantias_id; ?>">
+                                    <span class="button__icon"><i class="bx bx-paperclip"></i></span> <span class="button__text">Termo Garantia</span>
+                                </a>
+                            <?php } ?>
+                        </div>
+                    </div>
                     <?php if ($this->permission->checkPermission($this->session->userdata('permissao'), 'eOs')) {
                         $this->load->model('os_model');
                         $zapnumber = preg_replace("/[^0-9]/", "", $result->celular_cliente);
@@ -35,14 +48,13 @@
                         $texto_de_notificacao = $this->os_model->criarTextoWhats($texto_de_notificacao, $troca);
                         if (!empty($zapnumber)) {
                             echo '<a title="Via WhatsApp" class="button btn btn-mini btn-success" id="enviarWhatsApp" target="_blank" href="https://wa.me/send?phone=55' . $zapnumber . '&text=' . $texto_de_notificacao . '" ' . ($zapnumber == '' ? 'disabled' : '') . '>
-                            <span class="button__icon"><i class="bx bxl-whatsapp"></i></span> <span class="button__text">WhatsApp</span></a>';
+                                <span class="button__icon"><i class="bx bxl-whatsapp"></i></span> <span class="button__text">WhatsApp</span>
+                            </a>';
                         }
                     } ?>
-
                     <a title="Enviar por E-mail" class="button btn btn-mini btn-warning" href="<?php echo site_url() ?>/os/enviar_email/<?php echo $result->idOs; ?>">
-                        <span class="button__icon"><i class="bx bx-envelope"></i></span> <span class="button__text">Via E-mail</span></a>
-                    <?php if ($result->garantias_id) { ?> <a target="_blank" title="Imprimir Garantia" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/garantias/imprimirGarantiaOs/<?php echo $result->garantias_id; ?>">
-                            <span class="button__icon"><i class="bx bx-printer"></i></span> <span class="button__text">Garantia</span></a> <?php } ?>
+                        <span class="button__icon"><i class="bx bx-envelope"></i></span> <span class="button__text">Via E-mail</span>
+                    </a>
                 </div>
             </div>
             <div class="widget-content nopadding tab-content">
@@ -61,9 +73,7 @@
                                 <form action="<?php echo current_url(); ?>" method="post" id="formOs">
                                     <?php echo form_hidden('idOs', $result->idOs) ?>
                                     <div class="span12" style="padding: 1%; margin-left: 0">
-                                        <h3>N° OS:
-                                            <?php echo $result->idOs; ?>
-                                        </h3>
+                                        <h3>N° OS: <?php echo $result->idOs; ?></h3>
                                         <div class="span6" style="margin-left: 0">
                                             <label for="cliente">Cliente<span class="required">*</span></label>
                                             <input id="cliente" class="span12" type="text" name="cliente" value="<?php echo $result->nomeCliente ?>" />
@@ -80,42 +90,15 @@
                                         <div class="span3">
                                             <label for="status">Status<span class="required">*</span></label>
                                             <select class="span12" name="status" id="status" value="">
-                                                <option <?php if ($result->status == 'Orçamento') {
-                                                    echo 'selected';
-                                                } ?> value="Orçamento">Orçamento
-                                                </option>
-                                                <option <?php if ($result->status == 'Aberto') {
-                                                    echo 'selected';
-                                                } ?> value="Aberto">Aberto
-                                                </option>
-                                                <option <?php if ($result->status == 'Faturado') {
-                                                    echo 'selected';
-                                                } ?> value="Faturado">Faturado
-                                                </option>
-                                                <option <?php if ($result->status == 'Negociação') {
-                                                    echo 'selected';
-                                                } ?> value="Negociação">Negociação
-                                                </option>
-                                                <option <?php if ($result->status == 'Em Andamento') {
-                                                    echo 'selected';
-                                                } ?> value="Em Andamento">Em Andamento
-                                                </option>
-                                                <option <?php if ($result->status == 'Finalizado') {
-                                                    echo 'selected';
-                                                } ?> value="Finalizado">Finalizado
-                                                </option>
-                                                <option <?php if ($result->status == 'Cancelado') {
-                                                    echo 'selected';
-                                                } ?> value="Cancelado">Cancelado
-                                                </option>
-                                                <option <?php if ($result->status == 'Aguardando Peças') {
-                                                    echo 'selected';
-                                                } ?> value="Aguardando Peças">Aguardando Peças
-                                                </option>
-                                                <option <?php if ($result->status == 'Aprovado') {
-                                                    echo 'selected';
-                                                } ?> value="Aprovado">Aprovado
-                                                </option>
+                                                <option <?php if ($result->status == 'Orçamento') { echo 'selected'; } ?> value="Orçamento">Orçamento</option>
+                                                <option <?php if ($result->status == 'Aberto') { echo 'selected'; } ?> value="Aberto">Aberto</option>
+                                                <option <?php if ($result->status == 'Faturado') { echo 'selected'; } ?> value="Faturado">Faturado</option>
+                                                <option <?php if ($result->status == 'Negociação') { echo 'selected'; } ?> value="Negociação">Negociação</option>
+                                                <option <?php if ($result->status == 'Em Andamento') { echo 'selected'; } ?> value="Em Andamento">Em Andamento</option>
+                                                <option <?php if ($result->status == 'Finalizado') { echo 'selected'; } ?> value="Finalizado">Finalizado</option>
+                                                <option <?php if ($result->status == 'Cancelado') { echo 'selected'; } ?> value="Cancelado">Cancelado</option>
+                                                <option <?php if ($result->status == 'Aguardando Peças') { echo 'selected'; } ?> value="Aguardando Peças">Aguardando Peças</option>
+                                                <option <?php if ($result->status == 'Aprovado') { echo 'selected'; } ?> value="Aprovado">Aprovado</option>
                                             </select>
                                         </div>
                                         <div class="span3">
@@ -136,27 +119,19 @@
                                         </div>
                                     </div>
                                     <div class="span6" style="padding: 1%; margin-left: 0">
-                                        <label for="descricaoProduto">
-                                            <h4>Descrição Produto/Serviço</h4>
-                                        </label>
+                                        <label for="descricaoProduto"><h4>Descrição Produto/Serviço</h4></label>
                                         <textarea class="span12 editor" name="descricaoProduto" id="descricaoProduto" cols="30" rows="5"><?php echo $result->descricaoProduto ?></textarea>
                                     </div>
                                     <div class="span6" style="padding: 1%; margin-left: 0">
-                                        <label for="defeito">
-                                            <h4>Defeito</h4>
-                                        </label>
+                                        <label for="defeito"><h4>Defeito</h4></label>
                                         <textarea class="span12 editor" name="defeito" id="defeito" cols="30" rows="5"><?php echo $result->defeito ?></textarea>
                                     </div>
                                     <div class="span6" style="padding: 1%; margin-left: 0">
-                                        <label for="observacoes">
-                                            <h4>Observações</h4>
-                                        </label>
+                                        <label for="observacoes"><h4>Observações</h4></label>
                                         <textarea class="span12 editor" name="observacoes" id="observacoes" cols="30" rows="5"><?php echo $result->observacoes ?></textarea>
                                     </div>
                                     <div class="span6" style="padding: 1%; margin-left: 0">
-                                        <label for="laudoTecnico">
-                                            <h4>Laudo Técnico</h4>
-                                        </label>
+                                        <label for="laudoTecnico"><h4>Laudo Técnico</h4></label>
                                         <textarea class="span12 editor" name="laudoTecnico" id="laudoTecnico" cols="30" rows="5"><?php echo $result->laudoTecnico ?></textarea>
                                     </div>
                                     <div class="span12" style="padding: 0; margin-left: 0">
@@ -168,22 +143,10 @@
                                 </form>
                             </div>
                         </div>
-                        <!--Desconto-->
-                        <?php
-                        $total = 0;
-foreach ($produtos as $p) {
-    $total = $total + $p->subTotal;
-}
-?>
-                        <?php
-$totals = 0;
-foreach ($servicos as $s) {
-    $preco = $s->preco ?: $s->precoVenda;
-    $subtotals = $preco * ($s->quantidade ?: 1);
-    $totals = $totals + $subtotals;
-}
-?>
 
+                        <!--Desconto-->
+                        <?php $total = 0; foreach ($produtos as $p) {$total = $total + $p->subTotal;}?>
+                        <?php $totals = 0; foreach ($servicos as $s) { $preco = $s->preco ?: $s->precoVenda; $subtotals = $preco * ($s->quantidade ?: 1); $totals = $totals + $subtotals;}?>
                         <div class="tab-pane" id="tab2">
                             <div class="span12 well" style="padding: 1%; margin-left: 0">
                                 <form id="formDesconto" action="<?php echo base_url(); ?>index.php/os/adicionarDesconto" method="POST">
@@ -197,14 +160,16 @@ foreach ($servicos as $s) {
                                         <label for="">Tipo Desc.</label>
                                         <select style="width: 4em;" name="tipoDesconto" id="tipoDesconto">
                                             <option value="real">R$</option>
-                                            <option value="porcento" <?=$result->tipo_desconto == "porcento" ? "selected" : "" ?>>%</option>
+                                            <option value="porcento" <?= $result->tipo_desconto == "porcento" ? "selected" : "" ?>>%</option>
                                         </select>
                                         <strong><span style="color: red" id="errorAlert"></span></strong>
                                     </div>
                                     <div class="span3">
-                                        <input type="hidden" name="idOs" id="idOs" value="<?php echo $result->idOs; ?>" />
+                                        <input type="hidden" name="idOs" id="idOs"
+                                            value="<?php echo $result->idOs; ?>" />
                                         <label for="">Desconto</label>
-                                        <input style="width: 4em;" id="desconto" name="desconto" type="text" placeholder="" maxlength="6" size="2" value="<?=$result->desconto ?>"/>
+                                        <input style="width: 4em;" id="desconto" name="desconto" type="text"
+                                            placeholder="" maxlength="6" size="2" value="<?= $result->desconto ?>" />
                                         <strong><span style="color: red" id="errorAlert"></span></strong>
                                     </div>
                                     <div class="span2">
@@ -214,7 +179,8 @@ foreach ($servicos as $s) {
                                     <div class="span2">
                                         <label for="">&nbsp;</label>
                                         <button class="button btn btn-success" id="btnAdicionarDesconto">
-                                            <span class="button__icon"><i class='bx bx-plus-circle'></i></span><span class="button__text2">Aplicar</span></button>
+                                            <span class="button__icon"><i class='bx bx-plus-circle'></i></span> <span class="button__text2">Aplicar</span>
+                                        </button>
                                     </div>
                                 </form>
                             </div>
@@ -237,12 +203,14 @@ foreach ($servicos as $s) {
                                     </div>
                                     <div class="span2">
                                         <label for="">Quantidade</label>
-                                        <input type="text" placeholder="Quantidade" id="quantidade" name="quantidade" class="span12" />
+                                        <input type="text" placeholder="Quantidade" id="quantidade" name="quantidade"
+                                            class="span12" />
                                     </div>
                                     <div class="span2">
                                         <label for="">&nbsp;</label>
                                         <button class="button btn btn-success" id="btnAdicionarProduto">
-                                            <span class="button__icon"><i class='bx bx-plus-circle'></i></span><span class="button__text2">Adicionar</span></button>
+                                            <span class="button__icon"><i class='bx bx-plus-circle'></i></span> <span class="button__text2">Adicionar</span>
+                                        </button>
                                     </div>
                                 </form>
                             </div>
@@ -260,23 +228,28 @@ foreach ($servicos as $s) {
                                         </thead>
                                         <tbody>
                                             <?php
-                    $total = 0;
-foreach ($produtos as $p) {
-    $total = $total + $p->subTotal;
-    echo '<tr>';
-    echo '<td>' . $p->descricao . '</td>';
-    echo '<td><div align="center">' . $p->quantidade . '</td>';
-    echo '<td><div align="center">R$: ' . ($p->preco ?: $p->precoVenda)  . '</td>';
-    echo (strtolower($result->status) != "cancelado") ? '<td><div align="center"><a href="" idAcao="' . $p->idProdutos_os . '" prodAcao="' . $p->idProdutos . '" quantAcao="' . $p->quantidade . '" title="Excluir Produto" class="btn-nwe4"><i class="bx bx-trash-alt"></i></a></td>' : '<td></td>';
-    echo '<td><div align="center">R$: ' . number_format($p->subTotal, 2, ',', '.') . '</td>';
-    echo '</tr>';
-} ?>
+                                            $total = 0;
+                                            foreach ($produtos as $p) {
+                                                $total = $total + $p->subTotal;
+                                                echo '<tr>';
+                                                echo '<td>' . $p->descricao . '</td>';
+                                                echo '<td><div align="center">' . $p->quantidade . '</td>';
+                                                echo '<td><div align="center">R$: ' . ($p->preco ?: $p->precoVenda) . '</td>';
+                                                echo (strtolower($result->status) != "cancelado") ? '<td><div align="center"><a href="" idAcao="' . $p->idProdutos_os . '" prodAcao="' . $p->idProdutos . '" quantAcao="' . $p->quantidade . '" title="Excluir Produto" class="btn-nwe4"><i class="bx bx-trash-alt"></i></a></td>' : '<td></td>';
+                                                echo '<td><div align="center">R$: ' . number_format($p->subTotal, 2, ',', '.') . '</td>';
+                                                echo '</tr>';
+                                            } ?>
                                         </tbody>
                                         <tfoot>
                                             <tr>
-                                                <td colspan="4" style="text-align: right"><strong>Total:</strong></td>
+                                                <td colspan="4" style="text-align: right"><strong>Total:</strong>
+                                                </td>
                                                 <td>
-                                                    <div align="center"><strong>R$ <?php echo number_format($total, 2, ',', '.'); ?><input type="hidden" id="total-venda" value="<?php echo number_format($total, 2); ?>"></strong></div>
+                                                    <div align="center"><strong>R$
+                                                            <?php echo number_format($total, 2, ',', '.'); ?><input
+                                                                type="hidden" id="total-venda"
+                                                                value="<?php echo number_format($total, 2); ?>"></strong>
+                                                    </div>
                                                 </td>
                                             </tr>
                                         </tfoot>
@@ -288,25 +261,32 @@ foreach ($produtos as $p) {
                         <!--Serviços-->
                         <div class="tab-pane" id="tab4">
                             <div class="span12 well" style="padding: 1%; margin-left: 0">
-                                <form id="formServicos" action="<?php echo base_url() ?>index.php/os/adicionarServico" method="post">
+                                <form id="formServicos" action="<?php echo base_url() ?>index.php/os/adicionarServico"
+                                    method="post">
                                     <div class="span6">
                                         <input type="hidden" name="idServico" id="idServico" />
-                                        <input type="hidden" name="idOsServico" id="idOsServico" value="<?php echo $result->idOs; ?>" />
+                                        <input type="hidden" name="idOsServico" id="idOsServico"
+                                            value="<?php echo $result->idOs; ?>" />
                                         <label for="">Serviço</label>
-                                        <input type="text" class="span12" name="servico" id="servico" placeholder="Digite o nome do serviço" />
+                                        <input type="text" class="span12" name="servico" id="servico"
+                                            placeholder="Digite o nome do serviço" />
                                     </div>
                                     <div class="span2">
                                         <label for="">Preço</label>
-                                        <input type="text" placeholder="Preço" id="preco_servico" name="preco" class="span12 money" data-affixes-stay="true" data-thousands="" data-decimal="." />
+                                        <input type="text" placeholder="Preço" id="preco_servico" name="preco"
+                                            class="span12 money" data-affixes-stay="true" data-thousands=""
+                                            data-decimal="." />
                                     </div>
                                     <div class="span2">
                                         <label for="">Quantidade</label>
-                                        <input type="text" placeholder="Quantidade" id="quantidade_servico" name="quantidade" class="span12" />
+                                        <input type="text" placeholder="Quantidade" id="quantidade_servico"
+                                            name="quantidade" class="span12" />
                                     </div>
                                     <div class="span2">
                                         <label for="">&nbsp;</label>
                                         <button class="button btn btn-success">
-                                            <span class="button__icon"><i class='bx bx-plus-circle'></i></span><span class="button__text2">Adicionar</span></button>
+                                            <span class="button__icon"><i class='bx bx-plus-circle'></i></span><span
+                                                class="button__text2">Adicionar</span></button>
                                     </div>
                                 </form>
                             </div>
@@ -324,25 +304,30 @@ foreach ($produtos as $p) {
                                         </thead>
                                         <tbody>
                                             <?php
-$totals = 0;
-foreach ($servicos as $s) {
-    $preco = $s->preco ?: $s->precoVenda;
-    $subtotals = $preco * ($s->quantidade ?: 1);
-    $totals = $totals + $subtotals;
-    echo '<tr>';
-    echo '<td>' . $s->nome . '</td>';
-    echo '<td><div align="center">' . ($s->quantidade ?: 1) . '</div></td>';
-    echo '<td><div align="center">R$ ' . $preco  . '</div></td>';
-    echo '<td><div align="center"><span idAcao="' . $s->idServicos_os . '" title="Excluir Serviço" class="btn-nwe4 servico"><i class="bx bx-trash-alt"></i></span></div></td>';
-    echo '<td><div align="center">R$: ' . number_format($subtotals, 2, ',', '.') . '</div></td>';
-    echo '</tr>';
-} ?>
+                                            $totals = 0;
+                                            foreach ($servicos as $s) {
+                                                $preco = $s->preco ?: $s->precoVenda;
+                                                $subtotals = $preco * ($s->quantidade ?: 1);
+                                                $totals = $totals + $subtotals;
+                                                echo '<tr>';
+                                                echo '<td>' . $s->nome . '</td>';
+                                                echo '<td><div align="center">' . ($s->quantidade ?: 1) . '</div></td>';
+                                                echo '<td><div align="center">R$ ' . $preco . '</div></td>';
+                                                echo '<td><div align="center"><span idAcao="' . $s->idServicos_os . '" title="Excluir Serviço" class="btn-nwe4 servico"><i class="bx bx-trash-alt"></i></span></div></td>';
+                                                echo '<td><div align="center">R$: ' . number_format($subtotals, 2, ',', '.') . '</div></td>';
+                                                echo '</tr>';
+                                            } ?>
                                         </tbody>
                                         <tfoot>
                                             <tr>
-                                                <td colspan="4" style="text-align: right"><strong>Total:</strong></td>
+                                                <td colspan="4" style="text-align: right"><strong>Total:</strong>
+                                                </td>
                                                 <td>
-                                                    <div align="center"><strong>R$ <?php echo number_format($totals, 2, ',', '.'); ?><input type="hidden" id="total-servico" value="<?php echo number_format($totals, 2); ?>"></strong></div>
+                                                    <div align="center"><strong>R$
+                                                            <?php echo number_format($totals, 2, ',', '.'); ?><input
+                                                                type="hidden" id="total-servico"
+                                                                value="<?php echo number_format($totals, 2); ?>"></strong>
+                                                    </div>
                                                 </td>
                                             </tr>
                                         </tfoot>
@@ -355,16 +340,20 @@ foreach ($servicos as $s) {
                         <div class="tab-pane" id="tab5">
                             <div class="span12" style="padding: 1%; margin-left: 0">
                                 <div class="span12 well" style="padding: 1%; margin-left: 0" id="form-anexos">
-                                    <form id="formAnexos" enctype="multipart/form-data" action="javascript:;" accept-charset="utf-8" s method="post">
+                                    <form id="formAnexos" enctype="multipart/form-data" action="javascript:;"
+                                        accept-charset="utf-8" s method="post">
                                         <div class="span10">
-                                            <input type="hidden" name="idOsServico" id="idOsServico" value="<?php echo $result->idOs; ?>" />
+                                            <input type="hidden" name="idOsServico" id="idOsServico"
+                                                value="<?php echo $result->idOs; ?>" />
                                             <label for="">Anexo</label>
-                                            <input type="file" class="span12" name="userfile[]" multiple="multiple" size="20" />
+                                            <input type="file" class="span12" name="userfile[]" multiple="multiple"
+                                                size="20" />
                                         </div>
                                         <div class="span2">
                                             <label for="">.</label>
                                             <button class="button btn btn-success">
-                                                <span class="button__icon"><i class='bx bx-paperclip'></i></span><span class="button__text2">Anexar</span></button>
+                                                <span class="button__icon"><i class='bx bx-paperclip'></i></span><span
+                                                    class="button__text2">Anexar</span></button>
                                         </div>
                                     </form>
                                 </div>
@@ -384,7 +373,7 @@ foreach ($servicos as $s) {
                                                     </a>
                                                 </div>';
                                     }
-?>
+                                    ?>
                                 </div>
                             </div>
                         </div>
@@ -395,8 +384,10 @@ foreach ($servicos as $s) {
 
                                 <div class="span12" id="divAnotacoes" style="margin-left: 0">
 
-                                    <a href="#modal-anotacao" id="btn-anotacao" role="button" data-toggle="modal" class="button btn btn-success" style="max-width: 160px">
-                                        <span class="button__icon"><i class='bx bx-plus-circle'></i></span><span class="button__text2">Adicionar anotação</span></a>
+                                    <a href="#modal-anotacao" id="btn-anotacao" role="button" data-toggle="modal"
+                                        class="button btn btn-success" style="max-width: 160px">
+                                        <span class="button__icon"><i class='bx bx-plus-circle'></i></span><span
+                                            class="button__text2">Adicionar anotação</span></a>
                                     <hr>
                                     <table class="table table-bordered">
                                         <thead>
@@ -408,16 +399,16 @@ foreach ($servicos as $s) {
                                         </thead>
                                         <tbody>
                                             <?php
-                                                foreach ($anotacoes as $a) {
-                                                    echo '<tr>';
-                                                    echo '<td>' . date('d/m/Y H:i:s', strtotime($a->data_hora)) . '</td>';
-                                                    echo '<td>' . $a->anotacao . '</td>';
-                                                    echo '<td><span idAcao="' . $a->idAnotacoes . '" title="Excluir Anotação" class="btn-nwe4 anotacao"><i class="bx bx-trash-alt"></i></span></td>';
-                                                    echo '</tr>';
-                                                }
-                                                if (!$anotacoes) {
-                                                    echo '<tr><td colspan="3">Nenhuma anotação cadastrada</td></tr>';
-                                                }
+                                            foreach ($anotacoes as $a) {
+                                                echo '<tr>';
+                                                echo '<td>' . date('d/m/Y H:i:s', strtotime($a->data_hora)) . '</td>';
+                                                echo '<td>' . $a->anotacao . '</td>';
+                                                echo '<td><span idAcao="' . $a->idAnotacoes . '" title="Excluir Anotação" class="btn-nwe4 anotacao"><i class="bx bx-trash-alt"></i></span></td>';
+                                                echo '</tr>';
+                                            }
+                                            if (!$anotacoes) {
+                                                echo '<tr><td colspan="3">Nenhuma anotação cadastrada</td></tr>';
+                                            }
 
                                             ?>
                                         </tbody>
@@ -436,7 +427,8 @@ foreach ($servicos as $s) {
 </div>
 
 <!-- Modal visualizar anexo -->
-<div id="modal-anexo" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+<div id="modal-anexo" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel"
+    aria-hidden="true">
     <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
         <h3 id="myModalLabel">Visualizar Anexo</h3>
@@ -456,7 +448,8 @@ foreach ($servicos as $s) {
 </div>
 
 <!-- Modal cadastro anotações -->
-<div id="modal-anotacao" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+<div id="modal-anotacao" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel"
+    aria-hidden="true">
     <form action="#" method="POST" id="formAnotacao">
         <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
@@ -478,36 +471,44 @@ foreach ($servicos as $s) {
 </div>
 
 <!-- Modal Faturar-->
-<div id="modal-faturar" class="modal hide fade " tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+<div id="modal-faturar" class="modal hide fade " tabindex="-1" role="dialog" aria-labelledby="myModalLabel"
+    aria-hidden="true">
     <form id="formFaturar" action="<?php echo current_url() ?>" method="post">
         <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
             <h3 id="myModalLabel">Faturar OS</h3>
         </div>
         <div class="modal-body">
-            <div class="span12 alert alert-info" style="margin-left: 0"> Obrigatório o preenchimento dos campos com asterisco.</div>
+            <div class="span12 alert alert-info" style="margin-left: 0"> Obrigatório o preenchimento dos campos com
+                asterisco.</div>
             <div class="span12" style="margin-left: 0">
                 <label for="descricao">Descrição</label>
-                <input class="span12" id="descricao" type="text" name="descricao" value="Fatura de OS Nº: <?php echo $result->idOs; ?> " />
+                <input class="span12" id="descricao" type="text" name="descricao"
+                    value="Fatura de OS Nº: <?php echo $result->idOs; ?> " />
             </div>
             <div class="span12" style="margin-left: 0">
                 <div class="span12" style="margin-left: 0">
                     <label for="cliente">Cliente*</label>
-                    <input class="span12" id="cliente" type="text" name="cliente" value="<?php echo $result->nomeCliente ?>" />
+                    <input class="span12" id="cliente" type="text" name="cliente"
+                        value="<?php echo $result->nomeCliente ?>" />
                     <input type="hidden" name="clientes_id" id="clientes_id" value="<?php echo $result->clientes_id ?>">
                     <input type="hidden" name="os_id" id="os_id" value="<?php echo $result->idOs; ?>">
-                    <input type="hidden" name="tipoDesconto" id="tipoDesconto" value="<?php echo $result->tipo_desconto; ?>">
+                    <input type="hidden" name="tipoDesconto" id="tipoDesconto"
+                        value="<?php echo $result->tipo_desconto; ?>">
                 </div>
             </div>
             <div class="span12" style="margin-left: 0">
                 <div class="span6" style="margin-left: 0">
                     <label for="valor">Valor*</label>
                     <input type="hidden" id="tipo" name="tipo" value="receita" />
-                    <input class="span12 money" id="valor" type="text" data-affixes-stay="true" data-thousands="" data-decimal="." name="valor" value="<?php echo number_format($totals + $total, 2, '.', ''); ?>" />
+                    <input class="span12 money" id="valor" type="text" data-affixes-stay="true" data-thousands=""
+                        data-decimal="." name="valor"
+                        value="<?php echo number_format($totals + $total, 2, '.', ''); ?>" />
                 </div>
                 <div class="span6" style="margin-left: 2;">
                     <label for="valor">Valor Com Desconto*</label>
-                    <input class="span12 money" id="faturar-desconto" type="text" name="faturar-desconto" value="<?php echo number_format($result->valor_desconto, 2, '.', ''); ?> " />
+                    <input class="span12 money" id="faturar-desconto" type="text" name="faturar-desconto"
+                        value="<?php echo number_format($result->valor_desconto, 2, '.', ''); ?> " />
                     <strong><span style="color: red" id="resultado"></span></strong>
                 </div>
             </div>
@@ -525,7 +526,8 @@ foreach ($servicos as $s) {
                 <div id="divRecebimento" class="span8" style=" display: none">
                     <div class="span6">
                         <label for="recebimento">Data Recebimento</label>
-                        <input class="span12 datepicker" autocomplete="off" id="recebimento" type="text" name="recebimento" />
+                        <input class="span12 datepicker" autocomplete="off" id="recebimento" type="text"
+                            name="recebimento" />
                     </div>
                     <div class="span6">
                         <label for="formaPgto">Forma Pgto</label>
@@ -543,8 +545,11 @@ foreach ($servicos as $s) {
             </div>
         </div>
         <div class="modal-footer" style="display:flex;justify-content: center">
-            <button class="button btn btn-warning" data-dismiss="modal" aria-hidden="true" id="btn-cancelar-faturar"><span class="button__icon"><i class="bx bx-x"></i></span><span class="button__text2">Cancelar</span></button>
-            <button class="button btn btn-danger"><span class="button__icon"><i class='bx bx-dollar'></i></span> <span class="button__text2">Faturar</span></button>
+            <button class="button btn btn-warning" data-dismiss="modal" aria-hidden="true"
+                id="btn-cancelar-faturar"><span class="button__icon"><i class="bx bx-x"></i></span><span
+                    class="button__text2">Cancelar</span></button>
+            <button class="button btn btn-danger"><span class="button__icon"><i class='bx bx-dollar'></i></span>
+                <span class="button__text2">Faturar</span></button>
         </div>
     </form>
 </div>
@@ -572,20 +577,20 @@ foreach ($servicos as $s) {
     }
     var valorBackup = $("#valorTotal").val();
 
-    $("#quantidade").keyup(function() {
+    $("#quantidade").keyup(function () {
         this.value = this.value.replace(/[^0-9.]/g, '');
     });
 
-    $("#quantidade_servico").keyup(function() {
+    $("#quantidade_servico").keyup(function () {
         this.value = this.value.replace(/[^0-9.]/g, '');
     });
-    $('#tipoDesconto').on('change', function() {
+    $('#tipoDesconto').on('change', function () {
         if (Number($("#desconto").val()) >= 0) {
             $('#resultado').val(calcDesconto(Number($("#valorTotal").val()), Number($("#desconto").val()), $("#tipoDesconto").val()));
             $('#resultado').val(validarDesconto(Number($('#resultado').val()), Number($("#valorTotal").val())));
         }
     });
-    $("#desconto").keyup(function() {
+    $("#desconto").keyup(function () {
         this.value = this.value.replace(/[^0-9.]/g, '');
         if ($("#valorTotal").val() == null || $("#valorTotal").val() == '') {
             $('#errorAlert').text('Valor não pode ser apagado.').css("display", "inline").fadeOut(5000);
@@ -604,7 +609,7 @@ foreach ($servicos as $s) {
         }
     });
 
-    $("#valorTotal").focusout(function() {
+    $("#valorTotal").focusout(function () {
         $("#valorTotal").val(valorBackup);
         if ($("#valorTotal").val() == '0.00' && $('#resultado').val() != '') {
             $('#errorAlert').text('Você não pode apagar o valor.').css("display", "inline").fadeOut(6000);
@@ -619,7 +624,7 @@ foreach ($servicos as $s) {
         }
     });
 
-    $('#resultado').focusout(function() {
+    $('#resultado').focusout(function () {
         if (Number($('#resultado').val()) > Number($("#valorTotal").val())) {
             $('#errorAlert').text('Desconto não pode ser maior que o Valor.').css("display", "inline").fadeOut(6000);
             $('#resultado').val('');
@@ -629,11 +634,11 @@ foreach ($servicos as $s) {
             $('#resultado').val(validarDesconto(Number($('#resultado').val()), Number($("#valorTotal").val())));
         }
     });
-    $(document).ready(function() {
+    $(document).ready(function () {
 
         $(".money").maskMoney();
 
-        $('#recebido').click(function(event) {
+        $('#recebido').click(function (event) {
             var flag = $(this).is(':checked');
             if (flag == true) {
                 $('#divRecebimento').show();
@@ -672,7 +677,7 @@ foreach ($servicos as $s) {
                     required: 'Campo Requerido.'
                 }
             },
-            submitHandler: function(form) {
+            submitHandler: function (form) {
                 var dados = $(form).serialize();
                 var qtdProdutos = $('#tblProdutos >tbody >tr').length;
                 var qtdServicos = $('#tblServicos >tbody >tr').length;
@@ -692,7 +697,7 @@ foreach ($servicos as $s) {
                         url: "<?php echo base_url(); ?>index.php/os/faturar",
                         data: dados,
                         dataType: 'json',
-                        success: function(data) {
+                        success: function (data) {
                             if (data.result == true) {
                                 window.location.reload(true);
                             } else {
@@ -710,14 +715,14 @@ foreach ($servicos as $s) {
                 }
             }
         });
-        $('#formDesconto').submit(function(e) {
+        $('#formDesconto').submit(function (e) {
             e.preventDefault();
             var form = $(this);
             $.ajax({
                 url: form.attr('action'),
                 type: form.attr('method'),
                 data: form.serialize(),
-                beforeSend: function() {
+                beforeSend: function () {
                     Swal.fire({
                         title: 'Processando',
                         text: 'Registrando desconto...',
@@ -728,14 +733,14 @@ foreach ($servicos as $s) {
                         allowEscapeKey: false
                     });
                 },
-                success: function(response) {
+                success: function (response) {
                     if (response.result) {
                         Swal.fire({
                             type: "success",
                             title: "Sucesso",
                             text: response.messages
                         });
-                        setTimeout(function() {
+                        setTimeout(function () {
                             window.location.href = window.BaseUrl + 'index.php/os/editar/' + <?php echo $result->idOs ?>;
                         }, 2000);
                     } else {
@@ -747,7 +752,7 @@ foreach ($servicos as $s) {
                     }
 
                 },
-                error: function(response) {
+                error: function (response) {
                     Swal.fire({
                         type: "error",
                         title: "Atenção",
@@ -787,7 +792,7 @@ foreach ($servicos as $s) {
                     required: 'Campo Requerido.'
                 }
             },
-            submitHandler: function(form) {
+            submitHandler: function (form) {
                 var dados = $(form).serialize();
                 $('#btn-cancelar-faturar').trigger('click');
                 $.ajax({
@@ -795,7 +800,7 @@ foreach ($servicos as $s) {
                     url: "<?php echo base_url(); ?>index.php/os/faturar",
                     data: dados,
                     dataType: 'json',
-                    success: function(data) {
+                    success: function (data) {
                         if (data.result == true) {
 
                             window.location.reload(true);
@@ -817,7 +822,7 @@ foreach ($servicos as $s) {
         $("#produto").autocomplete({
             source: "<?php echo base_url(); ?>index.php/os/autoCompleteProduto",
             minLength: 2,
-            select: function(event, ui) {
+            select: function (event, ui) {
                 $("#codDeBarra").val(ui.item.codbar);
                 $("#idProduto").val(ui.item.id);
                 $("#estoque").val(ui.item.estoque);
@@ -829,7 +834,7 @@ foreach ($servicos as $s) {
         $("#servico").autocomplete({
             source: "<?php echo base_url(); ?>index.php/os/autoCompleteServico",
             minLength: 2,
-            select: function(event, ui) {
+            select: function (event, ui) {
                 $("#idServico").val(ui.item.id);
                 $("#preco_servico").val(ui.item.preco);
                 $("#quantidade_servico").focus();
@@ -840,7 +845,7 @@ foreach ($servicos as $s) {
         $("#cliente").autocomplete({
             source: "<?php echo base_url(); ?>index.php/os/autoCompleteCliente",
             minLength: 2,
-            select: function(event, ui) {
+            select: function (event, ui) {
                 $("#clientes_id").val(ui.item.id);
             }
         });
@@ -848,7 +853,7 @@ foreach ($servicos as $s) {
         $("#tecnico").autocomplete({
             source: "<?php echo base_url(); ?>index.php/os/autoCompleteUsuario",
             minLength: 2,
-            select: function(event, ui) {
+            select: function (event, ui) {
                 $("#usuarios_id").val(ui.item.id);
             }
         });
@@ -856,14 +861,14 @@ foreach ($servicos as $s) {
         $("#termoGarantia").autocomplete({
             source: "<?php echo base_url(); ?>index.php/os/autoCompleteTermoGarantia",
             minLength: 1,
-            select: function(event, ui) {
+            select: function (event, ui) {
                 if (ui.item.id) {
                     $("#garantias_id").val(ui.item.id);
                 }
             }
         });
 
-        $('#termoGarantia').on('change', function() {
+        $('#termoGarantia').on('change', function () {
             if (!$(this).val() && $("#garantias_id").val()) {
                 $("#garantias_id").val('');
                 Swal.fire({
@@ -899,10 +904,10 @@ foreach ($servicos as $s) {
             },
             errorClass: "help-inline",
             errorElement: "span",
-            highlight: function(element, errorClass, validClass) {
+            highlight: function (element, errorClass, validClass) {
                 $(element).parents('.control-group').addClass('error');
             },
-            unhighlight: function(element, errorClass, validClass) {
+            unhighlight: function (element, errorClass, validClass) {
                 $(element).parents('.control-group').removeClass('error');
                 $(element).parents('.control-group').addClass('success');
             }
@@ -925,13 +930,14 @@ foreach ($servicos as $s) {
                     required: 'Insira a quantidade'
                 }
             },
-            submitHandler: function(form) {
+            submitHandler: function (form) {
                 var quantidade = parseInt($("#quantidade").val());
                 var estoque = parseInt($("#estoque").val());
 
                 <?php if (!$configuration['control_estoque']) {
                     echo 'estoque = 1000000';
-                }; ?>
+                }
+                ; ?>
 
                 if (estoque < quantidade) {
                     Swal.fire({
@@ -947,7 +953,7 @@ foreach ($servicos as $s) {
                         url: "<?php echo base_url(); ?>index.php/os/adicionarProduto",
                         data: dados,
                         dataType: 'json',
-                        success: function(data) {
+                        success: function (data) {
                             if (data.result == true) {
                                 $("#divProdutos").load("<?php echo current_url(); ?> #divProdutos");
                                 $("#quantidade").val('');
@@ -993,7 +999,7 @@ foreach ($servicos as $s) {
                     required: 'Insira a quantidade'
                 },
             },
-            submitHandler: function(form) {
+            submitHandler: function (form) {
                 var dados = $(form).serialize();
 
                 $("#divServicos").html("<div class='progress progress-info progress-striped active'><div class='bar' style='width: 100%'></div></div>");
@@ -1002,7 +1008,7 @@ foreach ($servicos as $s) {
                     url: "<?php echo base_url(); ?>index.php/os/adicionarServico",
                     data: dados,
                     dataType: 'json',
-                    success: function(data) {
+                    success: function (data) {
                         if (data.result == true) {
                             $("#divServicos").load("<?php echo current_url(); ?> #divServicos");
                             $("#quantidade_servico").val('');
@@ -1035,7 +1041,7 @@ foreach ($servicos as $s) {
                     required: 'Insira a anotação'
                 }
             },
-            submitHandler: function(form) {
+            submitHandler: function (form) {
                 var dados = $(form).serialize();
                 $("#divFormAnotacoes").html("<div class='progress progress-info progress-striped active'><div class='bar' style='width: 100%'></div></div>");
 
@@ -1044,7 +1050,7 @@ foreach ($servicos as $s) {
                     url: "<?php echo base_url(); ?>index.php/os/adicionarAnotacao",
                     data: dados,
                     dataType: 'json',
-                    success: function(data) {
+                    success: function (data) {
                         if (data.result == true) {
                             $("#divAnotacoes").load("<?php echo current_url(); ?> #divAnotacoes");
                             $("#anotacao").val('');
@@ -1064,7 +1070,7 @@ foreach ($servicos as $s) {
         });
 
         $("#formAnexos").validate({
-            submitHandler: function(form) {
+            submitHandler: function (form) {
                 //var dados = $( form ).serialize();
                 var dados = new FormData(form);
                 $("#form-anexos").hide('1000');
@@ -1078,7 +1084,7 @@ foreach ($servicos as $s) {
                     cache: false,
                     processData: false,
                     dataType: 'json',
-                    success: function(data) {
+                    success: function (data) {
                         if (data.result == true) {
                             $("#divAnexos").load("<?php echo current_url(); ?> #divAnexos");
                             $("#userfile").val('');
@@ -1087,7 +1093,7 @@ foreach ($servicos as $s) {
                             $("#divAnexos").html('<div class="alert fade in"><button type="button" class="close" data-dismiss="alert">×</button><strong>Atenção!</strong> ' + data.mensagem + '</div>');
                         }
                     },
-                    error: function() {
+                    error: function () {
                         $("#divAnexos").html('<div class="alert alert-danger fade in"><button type="button" class="close" data-dismiss="alert">×</button><strong>Atenção!</strong> Ocorreu um erro. Verifique se você anexou o(s) arquivo(s).</div>');
                     }
                 });
@@ -1096,7 +1102,7 @@ foreach ($servicos as $s) {
             }
         });
 
-        $(document).on('click', 'a', function(event) {
+        $(document).on('click', 'a', function (event) {
             var idProduto = $(this).attr('idAcao');
             var quantidade = $(this).attr('quantAcao');
             var produto = $(this).attr('prodAcao');
@@ -1108,7 +1114,7 @@ foreach ($servicos as $s) {
                     url: "<?php echo base_url(); ?>index.php/os/excluirProduto",
                     data: "idProduto=" + idProduto + "&quantidade=" + quantidade + "&produto=" + produto + "&idOs=" + idOS,
                     dataType: 'json',
-                    success: function(data) {
+                    success: function (data) {
                         if (data.result == true) {
                             $("#divProdutos").load("<?php echo current_url(); ?> #divProdutos");
                             $("#divValorTotal").load("<?php echo current_url(); ?> #divValorTotal");
@@ -1129,7 +1135,7 @@ foreach ($servicos as $s) {
 
         });
 
-        $(document).on('click', '.servico', function(event) {
+        $(document).on('click', '.servico', function (event) {
             var idServico = $(this).attr('idAcao');
             var idOS = "<?php echo $result->idOs ?>"
             if ((idServico % 1) == 0) {
@@ -1139,7 +1145,7 @@ foreach ($servicos as $s) {
                     url: "<?php echo base_url(); ?>index.php/os/excluirServico",
                     data: "idServico=" + idServico + "&idOs=" + idOS,
                     dataType: 'json',
-                    success: function(data) {
+                    success: function (data) {
                         if (data.result == true) {
                             $("#divServicos").load("<?php echo current_url(); ?> #divServicos");
                             $("#divValorTotal").load("<?php echo current_url(); ?> #divValorTotal");
@@ -1159,7 +1165,7 @@ foreach ($servicos as $s) {
             }
         });
 
-        $(document).on('click', '.anexo', function(event) {
+        $(document).on('click', '.anexo', function (event) {
             event.preventDefault();
             var link = $(this).attr('link');
             var id = $(this).attr('imagem');
@@ -1171,7 +1177,7 @@ foreach ($servicos as $s) {
 
         });
 
-        $(document).on('click', '#excluir-anexo', function(event) {
+        $(document).on('click', '#excluir-anexo', function (event) {
             event.preventDefault();
             var link = $(this).attr('link');
             var idOS = "<?php echo $result->idOs ?>"
@@ -1183,7 +1189,7 @@ foreach ($servicos as $s) {
                 url: link,
                 dataType: 'json',
                 data: "idOs=" + idOS,
-                success: function(data) {
+                success: function (data) {
                     if (data.result == true) {
                         $("#divAnexos").load("<?php echo current_url(); ?> #divAnexos");
                     } else {
@@ -1197,7 +1203,7 @@ foreach ($servicos as $s) {
             });
         });
 
-        $(document).on('click', '.anotacao', function(event) {
+        $(document).on('click', '.anotacao', function (event) {
             var idAnotacao = $(this).attr('idAcao');
             var idOS = "<?php echo $result->idOs ?>"
             if ((idAnotacao % 1) == 0) {
@@ -1207,7 +1213,7 @@ foreach ($servicos as $s) {
                     url: "<?php echo base_url(); ?>index.php/os/excluirAnotacao",
                     data: "idAnotacao=" + idAnotacao + "&idOs=" + idOS,
                     dataType: 'json',
-                    success: function(data) {
+                    success: function (data) {
                         if (data.result == true) {
                             $("#divAnotacoes").load("<?php echo current_url(); ?> #divAnotacoes");
 

--- a/application/views/os/visualizarOs.php
+++ b/application/views/os/visualizarOs.php
@@ -10,13 +10,29 @@
                 <div class="buttons">
                     <?php if ($editavel) {
                         echo '<a title="Editar OS" class="button btn btn-mini btn-success" href="' . base_url() . 'index.php/os/editar/' . $result->idOs . '">
-    <span class="button__icon"><i class="bx bx-edit"></i> </span> <span class="button__text">Editar</span></a>';
+                            <span class="button__icon"><i class="bx bx-edit"></i> </span> <span class="button__text">Editar</span>
+                        </a>';
                     } ?>
 
-                    <a target="_blank" title="Imprimir OS" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/os/imprimir/<?php echo $result->idOs; ?>">
-                        <span class="button__icon"><i class="bx bx-printer"></i></span> <span class="button__text">Papel A4</span></a>
-                    <a target="_blank" title="Imprimir OS" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/os/imprimirTermica/<?php echo $result->idOs; ?>">
-                        <span class="button__icon"><i class="bx bx-printer"></i></span> <span class="button__text">CP Não Fiscal</span></a>
+                    <div class="button-container">
+                        <a target="_blank" title="Imprimir Ordem de Serviço" class="button btn btn-mini btn-inverse">
+                            <span class="button__icon"><i class="bx bx-printer"></i></span><span class="button__text">Imprimir</span>
+                        </a>
+                        <div class="cascading-buttons">
+                            <a target="_blank" title="Impressão em Ofício A4" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/os/imprimir/<?php echo $result->idOs; ?>">
+                                <span class="button__icon"><i class='bx bx-file'></i></span> <span class="button__text">Ofício A4</span>
+                            </a>
+                            <a target="_blank" title="Impressão Cupom Não Fical" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/os/imprimirTermica/<?php echo $result->idOs; ?>">
+                                <span class="button__icon"><i class='bx bx-receipt'></i></span> <span class="button__text">Cupom 80mm</span>
+                            </a>
+                            <?php if ($result->garantias_id) { ?>
+                                <a target="_blank" title="Imprimir Termo de Garantia" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/garantias/imprimirGarantiaOs/<?php echo $result->garantias_id; ?>">
+                                    <span class="button__icon"><i class="bx bx-paperclip"></i></span> <span class="button__text">Termo Garantia</span>
+                                </a>
+                            <?php } ?>
+                        </div>
+                    </div>
+
                     <?php if ($this->permission->checkPermission($this->session->userdata('permissao'), 'eOs')) {
                         $this->load->model('os_model');
                         $zapnumber = preg_replace("/[^0-9]/", "", $result->celular_cliente);
@@ -24,16 +40,18 @@
                         $texto_de_notificacao = $this->os_model->criarTextoWhats($texto_de_notificacao, $troca);
                         if (!empty($zapnumber)) {
                             echo '<a title="Enviar Por WhatsApp" class="button btn btn-mini btn-success" id="enviarWhatsApp" target="_blank" href="https://api.whatsapp.com/send?phone=55' . $zapnumber . '&text=' . $texto_de_notificacao . '">
-        <span class="button__icon"><i class="bx bxl-whatsapp"></i></span> <span class="button__text">WhatsApp</span></a>';
+                                <span class="button__icon"><i class="bx bxl-whatsapp"></i></span> <span class="button__text">WhatsApp</span>
+                            </a>';
                         }
                     } ?>
 
                     <a title="Enviar por E-mail" class="button btn btn-mini btn-warning" href="<?php echo site_url() ?>/os/enviar_email/<?php echo $result->idOs; ?>">
-                        <span class="button__icon"><i class="bx bx-envelope"></i></span> <span class="button__text">Via E-mail</span></a>
-                    <?php if ($result->garantias_id) { ?> <a target="_blank" title="Imprimir Termo de Garantia" class="button btn btn-mini btn-inverse" href="<?php echo site_url() ?>/garantias/imprimirGarantiaOs/<?php echo $result->garantias_id; ?>">
-                            <span class="button__icon"><i class="bx bx-printer"></i></span> <span class="button__text">Garantia</span></a> <?php } ?>
+                        <span class="button__icon"><i class="bx bx-envelope"></i></span> <span class="button__text">Via E-mail</span>
+                    </a>
+
                     <a href="#modal-gerar-pagamento" id="btn-forma-pagamento" role="button" data-toggle="modal" class="button btn btn-mini btn-info">
-                        <span class="button__icon"><i class='bx bx-qr'></i></span><span class="button__text">Gerar Pagamento</span></a></i>
+                        <span class="button__icon"><i class='bx bx-qr'></i></span><span class="button__text">Gerar Pagamento</span>
+                    </a>
                 </div>
             </div>
             <div class="widget-content" id="printOs">

--- a/assets/css/matrix-style.css
+++ b/assets/css/matrix-style.css
@@ -3792,6 +3792,15 @@ form {
     font-size: 1.05em;
   }
 
+  .widget-title .buttons .button-container>.btn {
+    width      : 32px !important;
+    min-width  : 32px;
+    white-space: nowrap;
+    overflow   : hidden;
+    position   : relative;
+    left       : 3px;
+  }
+
   .row-fluid select[class*="span"] {
     width     : 100% !important;
     margin-top: 0px;
@@ -4284,4 +4293,28 @@ fieldset[disabled] .btn-info.active {
 
 .table th, .table td{
   border-left: 0px solid #ddd;
+}
+
+/* Ajuste botões de impressão */
+.button-container {
+  position: relative;
+  display: inline-block;
+  margin: none;
+}
+
+.cascading-buttons {
+  display: none;
+  position: absolute;
+  top: 85%;
+  left: 0;
+  border-top: none;
+  z-index: 1;
+}
+
+.button-container:hover .cascading-buttons {
+  display: block;
+}
+
+.button-container .cascading-buttons a {
+  margin: 0 0 3px 0;
 }


### PR DESCRIPTION
Olá Srs,
Visando que a quantidade de tipos de impressão está crescendo dentro do projeto, segue melhoria com objetivo de otimizar a navegação e visualização do usuário desktop e mobile.
Ajustei os botões em um menu suspenso (agrupados) para listar os tipos de impressão nas páginas visualizarOS e editarOS, dando um espaço para PRs futuras que visa a variedade de tipos de impressão.

Evidências (Desktop):
![image](https://github.com/RamonSilva20/mapos/assets/45976190/38ccabaf-7b54-4709-a9ae-56a74ca65cc1)
![image](https://github.com/RamonSilva20/mapos/assets/45976190/a337fd90-85a3-4f40-8a8b-b71699493b55)

Evidências (Mobile)
![image](https://github.com/RamonSilva20/mapos/assets/45976190/488e3ac0-0c78-4df4-9872-79b32a591a76) ![image](https://github.com/RamonSilva20/mapos/assets/45976190/60f1a40e-6e8e-46d0-8995-52bc1a480ccd)
