### PR TITLE
Ajuste na paginação de OS na API

### DIFF
--- a/application/controllers/api/v1/OsController.php
+++ b/application/controllers/api/v1/OsController.php
@@ -52,7 +52,7 @@ class OsController extends REST_Controller
 
         if (! $id) {
             $perPage = $this->get('perPage', true) ?: 20;
-            $page = $this->get('page', true) ?: 0;
+            $page = $this->get('page', true) ? ($this->get('page', true) * $perPage) : 0;
             $start = $page ? ($perPage * $page) : 0;
 
             $oss = $this->os_model->getOs(


### PR DESCRIPTION
Depois da ultima PR de ajustes de segurança na API a paginação de OS parou de funcionar
Essa PR corrige o problema.