### PR TITLE
Mudando permissão para visualizarOs para gerar o zapnumber

### DIFF
--- a/application/views/os/visualizarOs.php
+++ b/application/views/os/visualizarOs.php
@@ -27,7 +27,7 @@
                         </div>
                     </div>
 
-                    <?php if ($this->permission->checkPermission($this->session->userdata('permissao'), 'eOs')) {
+                    <?php if ($this->permission->checkPermission($this->session->userdata('permissao'), 'vOs')) {
                         $this->load->model('os_model');
                         $zapnumber = preg_replace("/[^0-9]/", "", $result->celular_cliente);
                         $troca = [$result->nomeCliente, $result->idOs, $result->status, 'R$ ' . ($result->desconto != 0 && $result->valor_desconto != 0 ? number_format($result->valor_desconto, 2, ',', '.') : number_format($totalProdutos + $totalServico, 2, ',', '.')), strip_tags($result->descricaoProduto), ($emitente ? $emitente->nome : ''), ($emitente ? $emitente->telefone : ''), strip_tags($result->observacoes), strip_tags($result->defeito), strip_tags($result->laudoTecnico), date('d/m/Y', strtotime($result->dataFinal)), date('d/m/Y', strtotime($result->dataInicial)), $result->garantia . ' dias'];


### PR DESCRIPTION
Como está atualmente, se o usuário só tem permissão de visualizar OS o $zapnumber não é gerado, gerando erro para o usuário.

![image](https://github.com/user-attachments/assets/5261a080-c7dd-4ff8-8637-09dff578c038)

Com essa correção se o usuário tiver permissão para visualizarOs o $zapnumber é gerado normalmente