### PR TITLE
Corrigindo nome do cliente para Responsável

### DIFF
--- a/application/views/conecte/painel.php
+++ b/application/views/conecte/painel.php
@@ -56,7 +56,7 @@
                 <thead>
                     <tr>
                         <th>Nº</th>
-                        <th>Cliente</th>
+                        <th>Responsável</th>
                         <th>Data Inicial</th>
                         <th>Data Final</th>
                         <th>Venc. da Garantia</th>


### PR DESCRIPTION
Correção no nome cliente que na verdade é responsável.

![image](https://github.com/user-attachments/assets/37b9215b-6c9f-43de-9994-1cc8f2bfe063)
