### PR TITLE
Correções Lançamentos OS E Vendas

### DIFF
--- a/application/controllers/Os.php
+++ b/application/controllers/Os.php
@@ -1034,13 +1034,12 @@ class Os extends MY_Controller
             $valorTotal = $valorTotalServico + $valorTotalProduto;
             $valorTotalComDesconto = $valorTotal - $valorDesconto;
 
-            // Prepara os dados para inserção na tabela 'lancamentos'
             $data = [
                 'descricao' => set_value('descricao'),
-                'valor' => $valorTotal, // Valor total é sempre atribuído a 'valor'
+                'valor' => $valorTotal,
                 'tipo_desconto' => 'real',
-                'desconto' => ($valorDesconto > 0) ? $valorTotalComDesconto : 0, // Se houver desconto, usa valor com desconto, senão 0
-                'valor_desconto' => ($valorDesconto > 0) ? $valorDesconto : $valorTotal, // Se houver desconto, usa valor do desconto, senão valor total
+                'desconto' => ($valorDesconto > 0) ? $valorTotalComDesconto : 0,
+                'valor_desconto' => ($valorDesconto > 0) ? $valorDesconto : $valorTotal,
                 'clientes_id' => $this->input->post('clientes_id'),
                 'data_vencimento' => $vencimento,
                 'data_pagamento' => $recebimento,
@@ -1064,21 +1063,16 @@ class Os extends MY_Controller
                     ->set_output(json_encode(['result' => false]));
             }
 
-            // Inserção dos dados na tabela 'lancamentos'
             if ($this->os_model->add('lancamentos', $data)) {
-                // Atualização dos campos na tabela 'os'
                 $this->db->set('faturado', 1);
                 $this->db->set('valorTotal', $valorTotal);
 
-                // Atualiza tabela 'os'
                 if ($valorDesconto > 0) {
-                    // Se houver desconto
                     $this->db->set('desconto', $valorTotalComDesconto);
                     $this->db->set('valor_desconto', $valorDesconto);
                 } else {
-                    // Se não houver desconto
                     $this->db->set('desconto', 0);
-                    $this->db->set('valor_desconto', $valorTotal); // Valor total é atribuído a valor_desconto
+                    $this->db->set('valor_desconto', $valorTotal);
                 }
 
                 $this->db->set('status', 'Faturado');

--- a/application/controllers/Os.php
+++ b/application/controllers/Os.php
@@ -1016,23 +1016,31 @@ class Os extends MY_Controller
             $recebimento = $this->input->post('recebimento');
 
             try {
-                $vencimento = explode('/', $vencimento);
-                $vencimento = $vencimento[2] . '-' . $vencimento[1] . '-' . $vencimento[0];
-
+                $vencimento = DateTime::createFromFormat('d/m/Y', $vencimento)->format('Y-m-d');
                 if ($recebimento != null) {
-                    $recebimento = explode('/', $recebimento);
-                    $recebimento = $recebimento[2] . '-' . $recebimento[1] . '-' . $recebimento[0];
+                    $recebimento = DateTime::createFromFormat('d/m/Y', $recebimento)->format('Y-m-d');
                 }
             } catch (Exception $e) {
-                $vencimento = date('Y/m/d');
+                $vencimento = date('Y-m-d');
             }
-            $os = $this->os_model->getById($this->input->post('os_id'));
+
+            $os_id = $this->input->post('os_id');
+            $valorTotalData = $this->os_model->valorTotalOS($os_id);
+
+            $valorTotalServico = $valorTotalData['totalServico'];
+            $valorTotalProduto = $valorTotalData['totalProdutos'];
+            $valorDesconto = $valorTotalData['valor_desconto'];
+
+            $valorTotal = $valorTotalServico + $valorTotalProduto;
+            $valorTotalComDesconto = $valorTotal - $valorDesconto;
+
+            // Prepara os dados para inserção na tabela 'lancamentos'
             $data = [
                 'descricao' => set_value('descricao'),
-                'valor' => getAmount($this->input->post('valor')),
-                'tipo_desconto' => ($this->input->post('tipoDesconto')),
-                'desconto' => $os->desconto,
-                'valor_desconto' => $os->valor_desconto,
+                'valor' => $valorTotal, // Valor total é sempre atribuído a 'valor'
+                'tipo_desconto' => 'real',
+                'desconto' => ($valorDesconto > 0) ? $valorTotalComDesconto : 0, // Se houver desconto, usa valor com desconto, senão 0
+                'valor_desconto' => ($valorDesconto > 0) ? $valorDesconto : $valorTotal, // Se houver desconto, usa valor do desconto, senão valor total
                 'clientes_id' => $this->input->post('clientes_id'),
                 'data_vencimento' => $vencimento,
                 'data_pagamento' => $recebimento,
@@ -1042,37 +1050,60 @@ class Os extends MY_Controller
                 'tipo' => $this->input->post('tipo'),
                 'observacoes' => set_value('observacoes'),
                 'usuarios_id' => $this->session->userdata('id_admin'),
+                'os_id' => $os_id,
             ];
 
-            $editavel = $this->os_model->isEditable($this->input->post('idOs'));
-            if (! $editavel) {
+            $this->db->trans_start();
+
+            $editavel = $this->os_model->isEditable($os_id);
+            if (!$editavel) {
+                $this->db->trans_rollback();
                 return $this->output
                     ->set_content_type('application/json')
                     ->set_status_header(400)
                     ->set_output(json_encode(['result' => false]));
             }
 
-            if ($this->os_model->add('lancamentos', $data) == true) {
-                $os = $this->input->post('os_id');
-
+            // Inserção dos dados na tabela 'lancamentos'
+            if ($this->os_model->add('lancamentos', $data)) {
+                // Atualização dos campos na tabela 'os'
                 $this->db->set('faturado', 1);
-                $this->db->set('valorTotal', $this->input->post('valor'));
+                $this->db->set('valorTotal', $valorTotal);
+
+                // Atualiza tabela 'os'
+                if ($valorDesconto > 0) {
+                    // Se houver desconto
+                    $this->db->set('desconto', $valorTotalComDesconto);
+                    $this->db->set('valor_desconto', $valorDesconto);
+                } else {
+                    // Se não houver desconto
+                    $this->db->set('desconto', 0);
+                    $this->db->set('valor_desconto', $valorTotal); // Valor total é atribuído a valor_desconto
+                }
+
                 $this->db->set('status', 'Faturado');
-                $this->db->where('idOs', $os);
+                $this->db->where('idOs', $os_id);
                 $this->db->update('os');
 
-                log_info('Faturou uma OS. ID: ' . $os);
+                log_info('Faturou uma OS. ID: ' . $os_id);
 
-                $this->session->set_flashdata('success', 'OS faturada com sucesso!');
-                $json = ['result' => true];
-                echo json_encode($json);
-                exit();
+                $this->db->trans_complete();
+
+                if ($this->db->trans_status() === FALSE) {
+                    $this->session->set_flashdata('error', 'Ocorreu um erro ao tentar faturar OS.');
+                    $json = ['result' => false];
+                } else {
+                    $this->session->set_flashdata('success', 'OS faturada com sucesso!');
+                    $json = ['result' => true];
+                }
             } else {
+                $this->db->trans_rollback();
                 $this->session->set_flashdata('error', 'Ocorreu um erro ao tentar faturar OS.');
                 $json = ['result' => false];
-                echo json_encode($json);
-                exit();
             }
+
+            echo json_encode($json);
+            exit();
         }
 
         $this->session->set_flashdata('error', 'Ocorreu um erro ao tentar faturar OS.');

--- a/application/controllers/Vendas.php
+++ b/application/controllers/Vendas.php
@@ -562,10 +562,9 @@ class Vendas extends MY_Controller
 
             $valorDesconto = $valorDesconto > $valorTotal ? $valorTotal : $valorDesconto;
 
-            // Se não há desconto, o valor_desconto deve ser igual ao valorTotal
             $valorDesconto = $valorTotal - $valorDesconto;
             if ($valorDesconto == $valorTotal) {
-                $valorDesconto = $valorTotal; // Sem desconto
+                $valorDesconto = $valorTotal;
             }
 
             $data = [
@@ -573,7 +572,7 @@ class Vendas extends MY_Controller
                 'descricao' => set_value('descricao'),
                 'valor' => $valorTotal,
                 'desconto' => $vendas->desconto,
-                'tipo_desconto' => 'real', // Defina 'real' aqui
+                'tipo_desconto' => 'real',
                 'valor_desconto' => $valorDesconto,
                 'clientes_id' => $this->input->post('clientes_id'),
                 'data_vencimento' => $vencimento,

--- a/application/controllers/Vendas.php
+++ b/application/controllers/Vendas.php
@@ -573,7 +573,7 @@ class Vendas extends MY_Controller
                 'descricao' => set_value('descricao'),
                 'valor' => $valorTotal,
                 'desconto' => $vendas->desconto,
-                'tipo_desconto' => $vendas->tipo_desconto,
+                'tipo_desconto' => 'real', // Defina 'real' aqui
                 'valor_desconto' => $valorDesconto,
                 'clientes_id' => $this->input->post('clientes_id'),
                 'data_vencimento' => $vencimento,

--- a/application/views/mapos/painel.php
+++ b/application/views/mapos/painel.php
@@ -1033,7 +1033,7 @@
                         <th class="cliente-col">Cliente/Fornecedor</th>
                         <th class="descricao-col">Descrição</th>
                         <th class="vencimento-col">Vencimento</th>
-                        <th class="valor-col">V.T. Pago</th>
+                        <th class="valor-col">V.T. Faturado</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/application/views/vendas/vendas.php
+++ b/application/views/vendas/vendas.php
@@ -58,9 +58,9 @@
                         <th>Nº</th>
                         <th>Cliente</th>
                         <th>Data da Venda</th>
-                        <th>Vencimento da Garantia</th>
-                        <th>Faturado</th>
+                        <th>Venc. da Garantia</th>
                         <th>Status</th>
+                        <th>Faturado</th>
                         <th style="text-align:center">Ações</th>
                     </tr>
                 </thead>
@@ -140,8 +140,8 @@
                                     echo '<td><a href="' . base_url() . 'index.php/clientes/visualizar/' . $r->idClientes . '">' . $r->nomeCliente . '</a></td>';
                                     echo '<td>' . $dataVenda . '</td>';
                                     echo '<td class="ph3"><span class="badge" style="background-color: ' . $corGarantia . '; border-color: ' . $corGarantia . '">' . $vencGarantia . '</span> </td>';
-                                    echo '<td>' . $faturado . '</td>';
                                     echo '<td><span class="badge" style="background-color: ' . $cor . '; border-color: ' . $cor . '">' . $r->status . '</span> </td>';
+                                    echo '<td>' . $faturado . '</td>';
                                     echo '<td style="text-align:right">';
                                 if ($this->permission->checkPermission($this->session->userdata('permissao'), 'vVenda')) {
                                     echo '<a style="margin-right: 1%" href="' . base_url() . 'index.php/vendas/visualizar/' . $r->idVendas . '" class="btn-nwe" title="Ver mais detalhes"><i class="bx bx-show bx-xs"></i></a>';


### PR DESCRIPTION
Feita correção de quando faturar OS e Vendas para o lançamento inserir os valores corretamente. Sem a falha do desconto, ou que fique 0 sem os 2 digitos.

![image](https://github.com/user-attachments/assets/084a9ac3-fa48-4f24-acf8-905ab85077c1)

