### PR TITLE
fix(adicionarProduto): corrected profit margin calculation logic

### DIFF
--- a/application/views/produtos/adicionarProduto.php
+++ b/application/views/produtos/adicionarProduto.php
@@ -112,7 +112,7 @@
 <script src="<?php echo base_url(); ?>assets/js/maskmoney.js"></script>
 <script type="text/javascript">
     function calcLucro(precoCompra, margemLucro) {
-        var precoVenda = (precoCompra / (100 - margemLucro)*100).toFixed(2);
+        var precoVenda = (precoCompra * (1 + margemLucro / 100)).toFixed(2);
         return precoVenda;
     }
     $("#precoCompra").focusout(function() {


### PR DESCRIPTION
A lógica da função 'calcLucro' está incorreta para calcular o preço de venda baseado na margem de lucro.

Aqui está o problema:

- A fórmula que está sendo usada é:
  
  var precoVenda = (precoCompra / (100 - margemLucro)*100).toFixed(2);
  
  ![Imagem do WhatsApp de 2024-08-12 à(s) 11 45 38_e87a241a](https://github.com/user-attachments/assets/37866336-7dcf-4940-b132-28ed63bf09f5)

  Porém, isso não reflete corretamente como calcular o preço de venda baseado em uma margem de lucro.

Correção da Lógica:

A margem de lucro é tipicamente aplicada sobre o preço de custo, não em relação ao percentual restante. A fórmula correta para calcular o preço de venda com base no preço de compra ('precoCompra') e na margem de lucro ('margemLucro', em percentagem) é:

  var precoVenda = (precoCompra * (1 + margemLucro / 100)).toFixed(2);
  
  ![image](https://github.com/user-attachments/assets/b97fa614-c1d2-4e34-ad91-8b5c49eeefcf)

Essa fórmula adiciona a margem de lucro ao preço de custo para determinar o preço de venda.

Código Corrigido:

  function calcLucro(precoCompra, margemLucro) {
      var precoVenda = (precoCompra * (1 + margemLucro / 100)).toFixed(2);
      return precoVenda;
  }

Explicação:

- 'margemLucro / 100' converte a margem de lucro de percentual para decimal.
- '1 + margemLucro / 100' adiciona essa margem ao valor original (preço de compra).
- Multiplicando 'precoCompra' por esse fator, obtemos o preço de venda.
- '.toFixed(2)'

 garante que o resultado seja formatado com duas casas decimais.

Esse código agora retorna o preço de venda correto baseado na margem de lucro especificada.