### PR TITLE
Fix: Conseguir aplicar desconto na casa dos centavos, em valores acim…

### DIFF
--- a/application/views/os/editarOs.php
+++ b/application/views/os/editarOs.php
@@ -169,7 +169,7 @@
                                             value="<?php echo $result->idOs; ?>" />
                                         <label for="">Desconto</label>
                                         <input style="width: 4em;" id="desconto" name="desconto" type="text"
-                                            placeholder="" maxlength="6" size="2" value="<?= $result->desconto ?>" />
+                                            placeholder="" maxlength="7" size="2" value="<?= $result->desconto ?>" />
                                         <strong><span style="color: red" id="errorAlert"></span></strong>
                                     </div>
                                     <div class="span2">


### PR DESCRIPTION

![tela_erro-mapos-01](https://github.com/user-attachments/assets/205148fc-2f4f-4305-a6b2-79404a8fa1eb)
![tela_corrigido-mapos-01](https://github.com/user-attachments/assets/9989ea3a-f5f4-422e-bfa6-87c2fc9524a4)

Antes, o sistema não exibia a segunda casa decimal dos centavos quando o valor principal era superior a mil reais, o que impedia a aplicação correta do desconto nos centavos.