### PR TITLE
Correção Impressão Clientes

### DIFF
--- a/application/views/conecte/compras.php
+++ b/application/views/conecte/compras.php
@@ -131,8 +131,7 @@ if (!$results) { ?>
                         echo '<td>' . $faturado . '</td>';
                         echo '<td><span class="badge" style="background-color: ' . $cor . '; border-color: ' . $cor . '">' . $r->status . '</span> </td>';
                         echo '<td><a href="' . base_url() . 'index.php/mine/visualizarCompra/' . $r->idVendas . '" class="btn-nwe" title="Ver mais detalhes"><i class="bx bx-show"></i></a>
-                      <a href="' . base_url() . 'index.php/mine/imprimirCompra/' . $r->idVendas . '" class="btn-nwe6" title="Imprimir"><i class="bx bx-printer"></i></a>
-
+                      <a href="' . base_url() . 'index.php/mine/imprimirCompra/' . $r->idVendas . '" class="btn-nwe6" title="Imprimir" target="_blank"><i class="bx bx-printer"></i></a>
                   </td>';
                         echo '</tr>';
                     } ?>

--- a/application/views/conecte/os.php
+++ b/application/views/conecte/os.php
@@ -144,7 +144,7 @@ if (!$results) {
                             echo '<td><span class="badge" style="background-color: ' . $cor . '; border-color: ' . $cor . '">' . $r->status . '</span> </td>';
 
                             echo '<td><a href="' . base_url() . 'index.php/mine/visualizarOs/' . $r->idOs . '" class="btn-nwe" title="Visualizar e Imprimir"><i class="bx bx-show-alt"></i></a>
-                                  <a href="' . base_url() . 'index.php/mine/imprimirOs/' . $r->idOs . '" class="btn-nwe3" title="Imprimir"><i class="bx bx-printer"></i></a>
+                                  <a href="' . base_url() . 'index.php/mine/imprimirOs/' . $r->idOs . '" class="btn-nwe3" title="Imprimir" target="_blank"><i class="bx bx-printer"></i></a>
                                   <a href="' . base_url() . 'index.php/mine/detalhesOs/' . $r->idOs . '" class="btn-nwe4" title="Ver mais detalhes"><i class="bx bx-detail"></i></a>
                                   </td>';
                             echo '</tr>';

--- a/application/views/conecte/painel.php
+++ b/application/views/conecte/painel.php
@@ -132,7 +132,7 @@
                             echo '<td><span class="badge" style="background-color: ' . $cor . '; border-color: ' . $cor . '">' . $o->status . '</span> </td>';
                             echo '<td style="text-align:right">';
                             echo '<a href="' . base_url() . 'index.php/mine/visualizarOs/' . $o->idOs . '" class="btn"> <i class="fas fa-eye" ></i></a> ';
-                            echo '<a href="' . base_url() . 'index.php/mine/imprimirOs/' . $o->idOs . '" class="btn"> <i class="fas fa-print"></i></a>';
+                            echo '<a href="' . base_url('index.php/mine/imprimirOs/' . $o->idOs) . '" class="btn" target="_blank"> <i class="fas fa-print"></i></a>';
                             echo '</td>';
                             echo '</tr>';
                         }


### PR DESCRIPTION
Essa correção ajusta ao clicar em Imprimir na área do cliente, antes abria na mesma janela que estava, exemplo estava no painel clicava em imprimir ele abria a impressão na janela que estava aberto o Painel. com esse ajuste abre uma aba nova permitindo vc continua navegando no painel. Assim como é na impressão dos admins do sistema.

![image](https://github.com/user-attachments/assets/b334866d-21f1-4746-bbb2-190c11a9a9dd)
