### PR TITLE
Campo Contato area cliente

### DIFF
--- a/application/controllers/Mine.php
+++ b/application/controllers/Mine.php
@@ -328,6 +328,7 @@ class Mine extends CI_Controller
                     'cidade' => $this->input->post('cidade'),
                     'estado' => $this->input->post('estado'),
                     'cep' => $this->input->post('cep'),
+                    'contato' => $this->input->post('contato'),
                 ];
             } else {
                 $data = [
@@ -343,6 +344,7 @@ class Mine extends CI_Controller
                     'cidade' => $this->input->post('cidade'),
                     'estado' => $this->input->post('estado'),
                     'cep' => $this->input->post('cep'),
+                    'contato' => $this->input->post('contato'),
                 ];
             }
 
@@ -882,6 +884,7 @@ class Mine extends CI_Controller
                 'estado' => set_value('estado'),
                 'cep' => set_value('cep'),
                 'dataCadastro' => date('Y-m-d'),
+                'contato' => $this->input->post('contato'),
             ];
 
             $id = $this->clientes_model->add('clientes', $data);

--- a/application/views/conecte/cadastrar.php
+++ b/application/views/conecte/cadastrar.php
@@ -225,6 +225,13 @@
                     </div>
 
                     <div class="control-group" class="control-label">
+                        <label for="contato" class="control-label"><span class="required"></span></label>
+                        <div class="controls">
+                            <input id="contato" type="text" placeholder="Contato*" name="contato" value="<?= set_value('contato') ?>" />
+                        </div>
+                    </div>
+
+                    <div class="control-group" class="control-label">
                         <label for="estado" class="control-label"><span class="required"></span></label>
                         <div class="controls">
                             <select id="estado" name="estado">

--- a/application/views/conecte/cadastrar.php
+++ b/application/views/conecte/cadastrar.php
@@ -225,7 +225,7 @@
                     </div>
 
                     <div class="control-group" class="control-label">
-                        <label for="contato" class="control-label"><span class="required"></span></label>
+                        <label for="contato" class="control-label"></label>
                         <div class="controls">
                             <input id="contato" type="text" placeholder="Contato*" name="contato" value="<?= set_value('contato') ?>" />
                         </div>

--- a/application/views/conecte/conta.php
+++ b/application/views/conecte/conta.php
@@ -33,6 +33,12 @@
                                         </td>
                                     </tr>
                                     <tr>
+                                        <td style="text-align: right; width: 30%"><strong>Contato</strong></td>
+                                        <td>
+                                            <?php echo $result->contato ?>
+                                        </td>
+                                    </tr>
+                                    <tr>
                                         <td style="text-align: right"><strong>Documento</strong></td>
                                         <td>
                                             <?php echo $result->documento ?>

--- a/application/views/conecte/editar_dados.php
+++ b/application/views/conecte/editar_dados.php
@@ -22,6 +22,14 @@
                             <input id="nomeCliente" type="text" name="nomeCliente" value="<?php echo $result->nomeCliente; ?>" />
                         </div>
                     </div>
+
+                    <div class="control-group">
+                        <label for="contato" class="control-label">Contato</label>
+                        <div class="controls">
+                            <input id="contato" type="text" name="contato" value="<?php echo $result->contato; ?>" />
+                        </div>
+                    </div>
+
                     <div class="control-group">
                         <?php if ($custom_error != '') {
                             echo '<div class="alert alert-danger">' . $custom_error . '</div>';


### PR DESCRIPTION
Segue correções para cadastro area do cliente, adicionando o campo contato, para que tenha os dados de contato, assim como o cadastro na area admin.

Área de Cadastro cliente
![image](https://github.com/user-attachments/assets/fd619c14-0922-4b79-b70f-416050c5386c)

Visualizar dados.
![image](https://github.com/user-attachments/assets/0a180b67-267e-49de-a204-49aea4cea2c2)

Editar dados.

![editar](https://github.com/user-attachments/assets/872b5bcc-d182-4e99-871b-04410c9dea56)

