### PR TITLE
Paginação vendas

### DIFF
--- a/application/views/vendas/vendas.php
+++ b/application/views/vendas/vendas.php
@@ -156,6 +156,7 @@
             </table>
         </div>
     </div>
+    <?php echo $this->pagination->create_links(); ?>
 </div>
 
 <!-- Modal -->


### PR DESCRIPTION
Feita paginação nas vendas, que ao passar do limite em configurações não exibia as vendas mais antigas.

![image](https://github.com/user-attachments/assets/a18a049c-a91e-4f1d-8f97-16c2787a6a80)
