### PR TITLE
Data e hora na OS

### DIFF
--- a/application/controllers/Mapos.php
+++ b/application/controllers/Mapos.php
@@ -420,6 +420,7 @@ class Mapos extends MY_Controller {
         $this->form_validation->set_rules('control_editos', 'Controle de Edição de OS', 'required|trim');
         $this->form_validation->set_rules('control_edit_vendas', 'Controle de Edição de Vendas', 'required|trim');
         $this->form_validation->set_rules('control_datatable', 'Controle de Visualização em DataTables', 'required|trim');
+        $this->form_validation->set_rules('os_datetime', 'Utilizar Data/Hora na OS', 'required|trim');
         $this->form_validation->set_rules('os_status_list[]', 'Controle de visualização de OS', 'required|trim', ['required' => 'Selecione ao menos uma das opções!']);
         $this->form_validation->set_rules('control_2vias', 'Controle Impressão 2 Vias', 'required|trim');
         $this->form_validation->set_rules('pix_key', 'Chave Pix', 'trim|valid_pix_key', [
@@ -473,6 +474,7 @@ class Mapos extends MY_Controller {
                 'control_editos' => $this->input->post('control_editos'),
                 'control_edit_vendas' => $this->input->post('control_edit_vendas'),
                 'control_datatable' => $this->input->post('control_datatable'),
+                'os_datetime' => $this->input->post('os_datetime'),
                 'pix_key' => $this->input->post('pix_key'),
                 'os_status_list' => json_encode($this->input->post('os_status_list')),
                 'control_2vias' => $this->input->post('control_2vias'),
@@ -586,14 +588,14 @@ class Mapos extends MY_Controller {
 
             return [
                 'title' => "OS: {$os->idOs}, Cliente: {$os->nomeCliente}",
-                'start' => $os->dataFinal,
+                'start' => $os->dataInicial,
                 'end' => $os->dataFinal,
                 'color' => $cor,
                 'extendedProps' => [
                     'id' => $os->idOs,
                     'cliente' => '<b>Cliente:</b> ' . $os->nomeCliente,
-                    'dataInicial' => '<b>Data Inicial:</b> ' . date('d/m/Y', strtotime($os->dataInicial)),
-                    'dataFinal' => '<b>Data Final:</b> ' . date('d/m/Y', strtotime($os->dataFinal)),
+                    'dataInicial' => '<b>Data Inicial:</b> ' . date('d/m/Y H:i:s', strtotime($os->dataInicial)),
+                    'dataFinal' => '<b>Data Final:</b> ' . date('d/m/Y H:i:s', strtotime($os->dataFinal)),
                     'garantia' => '<b>Garantia:</b> ' . $os->garantia . ' dias',
                     'status' => '<b>Status da OS:</b> ' . $os->status,
                     'description' => '<b>Descrição/Produto:</b> ' . strip_tags(html_entity_decode($os->descricaoProduto)),

--- a/application/controllers/Os.php
+++ b/application/controllers/Os.php
@@ -113,10 +113,10 @@ class Os extends MY_Controller
             }
 
             $data = [
-                'dataInicial' => $dataInicial,
+                'dataInicial' => $this->formatarDataMysql($this->input->post('dataInicial')),
                 'clientes_id' => $this->input->post('clientes_id'), //set_value('idCliente'),
                 'usuarios_id' => $this->input->post('usuarios_id'), //set_value('idUsuario'),
-                'dataFinal' => $dataFinal,
+                'dataFinal' => $this->formatarDataMysql($this->input->post('dataFinal')),
                 'garantia' => set_value('garantia'),
                 'garantias_id' => $termoGarantiaId,
                 'descricaoProduto' => $this->input->post('descricaoProduto'),
@@ -216,8 +216,8 @@ class Os extends MY_Controller
             }
 
             $data = [
-                'dataInicial' => $dataInicial,
-                'dataFinal' => $dataFinal,
+                'dataInicial' => $this->formatarDataMysql($this->input->post('dataInicial')),
+                'dataFinal' => $this->formatarDataMysql($this->input->post('dataFinal')),
                 'garantia' => $this->input->post('garantia'),
                 'garantias_id' => $termoGarantiaId,
                 'descricaoProduto' => $this->input->post('descricaoProduto'),
@@ -1177,6 +1177,30 @@ class Os extends MY_Controller
             echo json_encode(['result' => true]);
         } else {
             echo json_encode(['result' => false]);
+        }
+    }
+
+    private function formatarDataMysql($data) 
+    {
+        if (empty($data)) {
+            return date('Y-m-d H:i:s'); // Retorna data atual se vazio
+        }
+
+        try {
+            // Tenta converter do formato brasileiro com hora
+            $date = DateTime::createFromFormat('d/m/Y H:i', $data);
+            if (!$date) {
+                // Tenta formato brasileiro sem hora
+                $date = DateTime::createFromFormat('d/m/Y', $data);
+            }
+            if (!$date) {
+                // Se ainda não conseguiu, tenta criar do formato que vier
+                $date = new DateTime($data);
+            }
+            
+            return $date->format('Y-m-d H:i:s');
+        } catch (Exception $e) {
+            return date('Y-m-d H:i:s'); // Retorna data atual se houver erro
         }
     }
 }

--- a/application/core/MY_Controller.php
+++ b/application/core/MY_Controller.php
@@ -31,6 +31,7 @@ class MY_Controller extends CI_Controller
             'control_baixa' => '0',
             'control_editos' => '1',
             'control_datatable' => '1',
+            'os_datetime' => '0',
             'pix_key' => '',
         ],
     ];

--- a/application/database/migrations/20210125173737_add_control_datatable.php
+++ b/application/database/migrations/20210125173737_add_control_datatable.php
@@ -6,10 +6,14 @@ class Migration_add_control_datatable extends CI_Migration
     {
         $sql = "INSERT INTO `configuracoes` (`idConfig`, `config`, `valor`) VALUES (10, 'control_datatable', 1)";
         $this->db->query($sql);
+
+        $sql = "INSERT INTO `configuracoes` (`idConfig`, `config`, `valor`) VALUES (16, 'os_datetime', 0)";
+        $this->db->query($sql);
     }
 
     public function down()
     {
         $this->db->query('DELETE FROM `configuracoes` WHERE `configuracoes`.`idConfig` = 10');
+        $this->db->query('DELETE FROM `configuracoes` WHERE `configuracoes`.`idConfig` = 16');
     }
 }

--- a/application/database/migrations/20240220000000_alter_datetime_os.php
+++ b/application/database/migrations/20240220000000_alter_datetime_os.php
@@ -1,0 +1,22 @@
+<?php
+
+class Migration_Alter_Datetime_Os extends CI_Migration
+{
+    public function up()
+    {
+        $sql = "ALTER TABLE os 
+                MODIFY COLUMN dataInicial DATETIME,
+                MODIFY COLUMN dataFinal DATETIME;";
+                
+        $this->db->query($sql);
+    }
+
+    public function down()
+    {
+        $sql = "ALTER TABLE os 
+                MODIFY COLUMN dataInicial DATE,
+                MODIFY COLUMN dataFinal DATE;";
+                
+        $this->db->query($sql);
+    }
+} 

--- a/application/database/seeds/Configuracoes.php
+++ b/application/database/seeds/Configuracoes.php
@@ -76,6 +76,11 @@ class Configuracoes extends Seeder
                 'config' => 'control_2vias',
                 'valor' => '0',
             ],
+            [
+                'idConfig' => 16,
+                'config' => 'os_datetime',
+                'valor' => '0',
+            ],
         ];
 
         foreach ($configs as $config) {

--- a/application/views/mapos/configurar.php
+++ b/application/views/mapos/configurar.php
@@ -66,6 +66,16 @@
                                 <span class="help-inline">Ativar ou desativar a visualização em tabelas dinâmicas</span>
                             </div>
                         </div>
+                        <div class="control-group">
+                            <label for="os_datetime" class="control-label">Utilizar Data/Hora na OS</label>
+                            <div class="controls">
+                                <select name="os_datetime" id="os_datetime">
+                                    <option value="1">Sim</option>
+                                    <option value="0" <?= $configuration['os_datetime'] == '0' ? 'selected' : ''; ?>>Não</option>
+                                </select>
+                                <span class="help-inline">Ativar ou desativar data e hora na OS</span>
+                            </div>
+                        </div>
                         <div class="form-actions">
                             <div class="span8">
                                 <div class="span9">

--- a/application/views/mapos/painel.php
+++ b/application/views/mapos/painel.php
@@ -1253,7 +1253,7 @@
             selectable: false,
             businessHours: true,
             dayMaxEvents: true, // allow "more" link when too many events
-            displayEventTime: false,
+            displayEventTime: true,
             events: {
                 url: "<?= base_url() . "index.php/mapos/calendario"; ?>",
                 method: 'GET',

--- a/application/views/os/adicionarOs.php
+++ b/application/views/os/adicionarOs.php
@@ -57,11 +57,11 @@
                                         </div>
                                         <div class="span3">
                                             <label for="dataInicial">Data Inicial<span class="required">*</span></label>
-                                            <input id="dataInicial" autocomplete="off" class="span12 datepicker" type="text" name="dataInicial" value="<?php echo date('d/m/Y'); ?>" />
+                                            <input id="dataInicial" autocomplete="off" class="span12 datepicker" <?php echo $configuration['os_datetime'] ? 'type="datetime-local"' : 'type="text"'; ?> name="dataInicial" value="<?php echo date('d/m/Y'); ?>" />
                                         </div>
                                         <div class="span3">
                                             <label for="dataFinal">Data Final<span class="required">*</span></label>
-                                            <input id="dataFinal" autocomplete="off" class="span12 datepicker" type="text" name="dataFinal" value="" />
+                                            <input id="dataFinal" autocomplete="off" class="span12 datepicker" <?php echo $configuration['os_datetime'] ? 'type="datetime-local"' : 'type="text"'; ?> name="dataFinal" value="<?php echo date('d/m/Y'); ?>" />
                                         </div>
                                         <div class="span3">
                                             <label for="garantia">Garantia (dias)</label>

--- a/application/views/os/editarOs.php
+++ b/application/views/os/editarOs.php
@@ -102,12 +102,12 @@
                                             </select>
                                         </div>
                                         <div class="span3">
-                                            <label for="dataInicial">Data Inicial<span class="required">*</span></label>
-                                            <input id="dataInicial" autocomplete="off" class="span12 datepicker" type="text" name="dataInicial" value="<?php echo date('d/m/Y', strtotime($result->dataInicial)); ?>" />
+                                            <label for="dataInicial">Data Inicial | <?php echo date('d/m/Y H:i', strtotime($result->dataInicial)); ?> |<span class="required">*</span></label>
+                                            <input id="dataInicial" autocomplete="off" class="span12 datepicker" <?php echo $configuration['os_datetime'] ? 'type="datetime-local"' : 'type="text"'; ?> name="dataInicial" value="<?php echo $configuration['os_datetime'] ? date('Y-m-d\TH:i', strtotime($result->dataInicial)) : date('d/m/Y', strtotime($result->dataInicial)); ?>" />
                                         </div>
                                         <div class="span3">
                                             <label for="dataFinal">Data Final<span class="required">*</span></label>
-                                            <input id="dataFinal" autocomplete="off" class="span12 datepicker" type="text" name="dataFinal" value="<?php echo date('d/m/Y', strtotime($result->dataFinal)); ?>" />
+                                            <input id="dataFinal" autocomplete="off" class="span12 datepicker" <?php echo $configuration['os_datetime'] ? 'type="datetime-local"' : 'type="text"'; ?> name="dataFinal" value="<?php echo $configuration['os_datetime'] ? date('Y-m-d\TH:i', strtotime($result->dataFinal)) : date('d/m/Y', strtotime($result->dataFinal)); ?>" />
                                         </div>
                                         <div class="span3">
                                             <label for="garantia">Garantia (dias)</label>

--- a/application/views/os/editarOs.php
+++ b/application/views/os/editarOs.php
@@ -102,7 +102,7 @@
                                             </select>
                                         </div>
                                         <div class="span3">
-                                            <label for="dataInicial">Data Inicial | <?php echo date('d/m/Y H:i', strtotime($result->dataInicial)); ?> |<span class="required">*</span></label>
+                                            <label for="dataInicial">Data Inicial<span class="required">*</span></label>
                                             <input id="dataInicial" autocomplete="off" class="span12 datepicker" <?php echo $configuration['os_datetime'] ? 'type="datetime-local"' : 'type="text"'; ?> name="dataInicial" value="<?php echo $configuration['os_datetime'] ? date('Y-m-d\TH:i', strtotime($result->dataInicial)) : date('d/m/Y', strtotime($result->dataInicial)); ?>" />
                                         </div>
                                         <div class="span3">

--- a/application/views/os/os.php
+++ b/application/views/os/os.php
@@ -82,9 +82,9 @@
                         }
 
                         $this->load->model('os_model'); foreach ($results as $r) {
-                                $dataInicial = date(('d/m/Y'), strtotime($r->dataInicial));
+                                $dataInicial = $configuration['os_datetime'] ? date(('d/m/Y H:i'), strtotime($r->dataInicial)) : date(('d/m/Y'), strtotime($r->dataInicial));
                                 if ($r->dataFinal != null) {
-                                    $dataFinal = date(('d/m/Y'), strtotime($r->dataFinal));
+                                    $dataFinal = $configuration['os_datetime'] ? date(('d/m/Y H:i'), strtotime($r->dataFinal)) : date(('d/m/Y'), strtotime($r->dataFinal));
                                 } else {
                                     $dataFinal = "";
                                 }

--- a/application/views/os/visualizarOs.php
+++ b/application/views/os/visualizarOs.php
@@ -136,12 +136,12 @@
 
                                         <td>
                                             <b>DATA INICIAL: </b><br>
-                                            <?php echo date('d/m/Y', strtotime($result->dataInicial)); ?>
+                                            <?php echo date('d/m/Y H:i', strtotime($result->dataInicial)); ?>
                                         </td>
 
                                         <td>
                                             <b>DATA FINAL: </b><br>
-                                            <?php echo $result->dataFinal ? date('d/m/Y', strtotime($result->dataFinal)) : ''; ?>
+                                            <?php echo $result->dataFinal ? date('d/m/Y H:i', strtotime($result->dataFinal)) : ''; ?>
                                         </td>
 
                                         <td>

--- a/banco.sql
+++ b/banco.sql
@@ -212,8 +212,8 @@ DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS `os` (
   `idOs` INT(11) NOT NULL AUTO_INCREMENT,
-  `dataInicial` DATE NULL DEFAULT NULL,
-  `dataFinal` DATE NULL DEFAULT NULL,
+  `dataInicial` DATETIME NULL DEFAULT NULL,
+  `dataFinal` DATETIME NULL DEFAULT NULL,
   `garantia` VARCHAR(45) NULL DEFAULT NULL,
   `descricaoProduto` TEXT NULL DEFAULT NULL,
   `defeito` TEXT NULL DEFAULT NULL,
@@ -649,7 +649,8 @@ INSERT IGNORE INTO `configuracoes` (`idConfig`, `config`, `valor`) VALUES
 (12, 'os_status_list', '[\"Aberto\",\"Faturado\",\"Negocia\\u00e7\\u00e3o\",\"Em Andamento\",\"Or\\u00e7amento\",\"Finalizado\",\"Cancelado\",\"Aguardando Pe\\u00e7as\",\"Aprovado\"]'),
 (13, 'control_edit_vendas', '1'),
 (14, 'email_automatico', '1'),
-(15, 'control_2vias', '0');
+(15, 'control_2vias', '0'),
+(16, 'os_datetime', '1');
 
 INSERT IGNORE INTO `permissoes` (`idPermissao`, `nome`, `permissoes`, `situacao`, `data`) VALUES
 (1, 'Administrador', 'a:53:{s:8:"aCliente";s:1:"1";s:8:"eCliente";s:1:"1";s:8:"dCliente";s:1:"1";s:8:"vCliente";s:1:"1";s:8:"aProduto";s:1:"1";s:8:"eProduto";s:1:"1";s:8:"dProduto";s:1:"1";s:8:"vProduto";s:1:"1";s:8:"aServico";s:1:"1";s:8:"eServico";s:1:"1";s:8:"dServico";s:1:"1";s:8:"vServico";s:1:"1";s:3:"aOs";s:1:"1";s:3:"eOs";s:1:"1";s:3:"dOs";s:1:"1";s:3:"vOs";s:1:"1";s:6:"aVenda";s:1:"1";s:6:"eVenda";s:1:"1";s:6:"dVenda";s:1:"1";s:6:"vVenda";s:1:"1";s:9:"aGarantia";s:1:"1";s:9:"eGarantia";s:1:"1";s:9:"dGarantia";s:1:"1";s:9:"vGarantia";s:1:"1";s:8:"aArquivo";s:1:"1";s:8:"eArquivo";s:1:"1";s:8:"dArquivo";s:1:"1";s:8:"vArquivo";s:1:"1";s:10:"aPagamento";N;s:10:"ePagamento";N;s:10:"dPagamento";N;s:10:"vPagamento";N;s:11:"aLancamento";s:1:"1";s:11:"eLancamento";s:1:"1";s:11:"dLancamento";s:1:"1";s:11:"vLancamento";s:1:"1";s:8:"cUsuario";s:1:"1";s:9:"cEmitente";s:1:"1";s:10:"cPermissao";s:1:"1";s:7:"cBackup";s:1:"1";s:10:"cAuditoria";s:1:"1";s:6:"cEmail";s:1:"1";s:8:"cSistema";s:1:"1";s:8:"rCliente";s:1:"1";s:8:"rProduto";s:1:"1";s:8:"rServico";s:1:"1";s:3:"rOs";s:1:"1";s:6:"rVenda";s:1:"1";s:11:"rFinanceiro";s:1:"1";s:9:"aCobranca";s:1:"1";s:9:"eCobranca";s:1:"1";s:9:"dCobranca";s:1:"1";s:9:"vCobranca";s:1:"1";}', 1, 'admin_created_at');

--- a/updates/update_4.29.0_to_4.30.0.sql
+++ b/updates/update_4.29.0_to_4.30.0.sql
@@ -2,4 +2,6 @@ INSERT INTO `configuracoes` (`idConfig`, `config`, `valor`) VALUES (9, 'control_
 
 INSERT INTO `configuracoes` (`idConfig`, `config`, `valor`) VALUES (10, 'control_datatable', 1);
 
+INSERT INTO `configuracoes` (`idConfig`, `config`, `valor`) VALUES (16, 'os_datetime', 0);
+
 ALTER TABLE `clientes` ADD `fornecedor` BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
 - Exibição de data e hora da OS no calendário;
 - Criação de configuração para ativar ou desativar o recurso (por padrão inativo);
 - Nos campos de data na criação e edição da OS foi alterado o tipo de campo para exibir hora a selecionar pelo usuário;
 - Criado script de upgrade e downgrade para os campos de data inicial e data final da OS;
 - Criado script de upgrade e downgrade para inserir ou remover a configuração nova que habilita o recurso;
 Configuração nova:
![image](https://github.com/user-attachments/assets/709a3dae-a0f3-4be1-abe4-15e1444ec28b)

 Consulta OSs:
![image](https://github.com/user-attachments/assets/e3113489-41dd-42d7-84ec-e59f210d4660)

Calendário:
![image](https://github.com/user-attachments/assets/643439fd-bbb2-4e50-9737-3016aa26c6cf)

Tela inserção nova OS:
![image](https://github.com/user-attachments/assets/a32950d5-e49c-4746-ac69-b1d7d7594469)

Tela edição OS:
![image](https://github.com/user-attachments/assets/df914d51-4249-4faa-99c5-69a669e84477)

Se desabilitar a configuração, as telas voltam a ser como anteriormente. Já testado campos com config habilitada e desabilitada.
Não solicitado permissão para alterar o código por não encontrar informações sobre o procedimento. Precisei do recurso e achei legal disponibilizar, espero que seja útil e alinhado com o projeto.
Obrigado!