### PR TITLE
Correção adicionar Fornecedor

### DIFF
--- a/application/controllers/Clientes.php
+++ b/application/controllers/Clientes.php
@@ -86,7 +86,7 @@ class Clientes extends MY_Controller
                 'estado' => set_value('estado'),
                 'cep' => set_value('cep'),
                 'dataCadastro' => date('Y-m-d'),
-                'fornecedor' => (set_value('fornecedor') == true ? 1 : 0),
+                'fornecedor' => $this->input->post('fornecedor') ? 1 : 0,
             ];
 
             if ($this->clientes_model->add('clientes', $data) == true) {

--- a/application/views/clientes/adicionarCliente.php
+++ b/application/views/clientes/adicionarCliente.php
@@ -139,7 +139,7 @@
                             <label class="control-label">Tipo de Cliente</label>
                             <div class="controls">
                                 <label for="fornecedor" class="btn btn-default">Fornecedor
-                                    <input type="checkbox" id="fornecedor" name="fornecedor" class="badgebox" value="0">
+                                    <input type="checkbox" id="fornecedor" name="fornecedor" class="badgebox" value="1">
                                     <span class="badge">&check;</span>
                                 </label>
                             </div>


### PR DESCRIPTION
Correção ao adicionar Fornecedor, corrigindo os campos para ao adicionar fornecedor os dados sejam enviados corretamente ao banco de dados.

![image](https://github.com/user-attachments/assets/235a99d9-a486-49d2-8d1a-4135f39c7dde)

Agora ao marcar o campo fornecedor ele é enviado corretamente e salvo como fornecedor.