### PR TITLE
OS | Termo de Garantia

### DIFF
--- a/application/views/os/imprimirOs.php
+++ b/application/views/os/imprimirOs.php
@@ -125,12 +125,19 @@
 
                 <?php if ($result->laudoTecnico) : ?>
 					<div class="subtitle">PARECER TÉCNICO</div>
-							<div class="dados">
-									<div style="text-align: justify;">
-						<?= htmlspecialchars_decode($result->laudoTecnico) ?>
+                    <div class="dados">
+                        <div style="text-align: justify;">
+    						<?= htmlspecialchars_decode($result->laudoTecnico) ?>
 						</div>
-						</div>
-					<?php endif; ?>
+                    </div>
+                <?php endif; ?>
+
+                <?php if ($result->garantias_id) : ?>
+                    <div class="subtitle">TERMO DE GARANTIA</div>
+                    <div class="dados">
+                        <div style="text-align: justify;"><?= htmlspecialchars_decode($result->textoGarantia) ?></div>
+                    </div>
+                <?php endif; ?>
 
                 <?php if ($produtos) : ?>
                     <div class="tabela">
@@ -376,6 +383,13 @@
                             <div>
                                 <?= htmlspecialchars_decode($result->laudoTecnico) ?>
                             </div>
+                        </div>
+                    <?php endif; ?>
+
+                    <?php if ($result->garantias_id) : ?>
+                        <div class="subtitle">TERMO DE GARANTIA</div>
+                        <div class="dados">
+                            <div style="text-align: justify;"><?= htmlspecialchars_decode($result->textoGarantia) ?></div>
                         </div>
                     <?php endif; ?>
 


### PR DESCRIPTION
A alguns versões atrás desenvolvemos um novo layout da impressão A4 no sistema, porém o texto do Termo de Garantia ficou fora, recebemos alguns reports quanto a falta desse campo na impressão e estou adicionando novamente, Uma vez que o termo não é vinculado ele não é impresso, sugiro adicionar novamente o componente.

Evidência
![image](https://github.com/user-attachments/assets/0474d988-6e93-486b-804b-ae043de8aa2d)
