### PR TITLE
Área do Cliente | Cadastrar - Botão Voltar

### DIFF
--- a/application/views/conecte/cadastrar.php
+++ b/application/views/conecte/cadastrar.php
@@ -254,7 +254,7 @@
                     <div class="span12">
                         <div class="span6 offset3" style="display:flex;justify-content: center">
                             <button type="submit" class="button btn btn-success btn-large"><span class="button__icon"><i class='bx bx-user-plus'></i></span><span class="button__text2">Cadastrar</span></button>
-                            <a href="<?= base_url() ?>index.php/mine" id="" class="button btn btn-warning"><span class="button__icon"><i class='bx bx-lock-alt'></i></span><span class="button__text2">Acessar</span></a>
+                            <a href="<?= base_url() ?>index.php/mine" id="" class="button btn btn-warning"><span class="button__icon"><i class='bx bx-undo'></i></span><span class="button__text2">Voltar</span></a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Recebemos reportes de situações em que usuários (clientes) mais leigos ao tentar se cadastrar confundem o botão Acessar com a função Cadastrar perdendo todo o preenchimento e retornando a página de login da Área do Cliente, então sugerimos que o botão "Acessar" passe a ser "Voltar" remetendo a sua real funcionalidade.

![2025-04-01_22-53](https://github.com/user-attachments/assets/4ab41b9a-0bb2-40f5-9d90-e1d37602c0b4)