### PR TITLE
corrigir numero zap vendas

### DIFF
--- a/application/controllers/Vendas.php
+++ b/application/controllers/Vendas.php
@@ -211,6 +211,12 @@ class Vendas extends MY_Controller
             true
         );
 
+        $clienteId = $this->data['result']->clientes_id;
+        $this->load->model('clientes_model');
+        $cliente = $this->clientes_model->getById($clienteId);
+
+        $zapnumber = preg_replace('/[^0-9]/', '', $cliente->telefone ?? '');
+        $this->data['zapnumber'] = $zapnumber;
         $this->data['view'] = 'vendas/visualizarVenda';
 
         return $this->layout();


### PR DESCRIPTION
Nessa correção venho adicionar o numero da função zapnumber que estava vazio e por isso o botão não aparecia.

![image](https://github.com/user-attachments/assets/243feaeb-8072-4c28-afa9-1a434dc3a002)

Agora o botão para envio pelo whatsapp funciona.