### PR TITLE
Não permitindo quebrar section em impressão

### DIFF
--- a/assets/css/imprimir.css
+++ b/assets/css/imprimir.css
@@ -121,6 +121,7 @@ section .dados {
     line-height: 20px;
     display: flex;
     justify-content: space-between;
+    page-break-inside: avoid;
 }
 
 section .dados p {
@@ -185,6 +186,8 @@ footer {
     width: 100%;
     padding: 10px;
     border: 1px solid #cdcdcd;
+    page-break-before: avoid;
+    page-break-inside: avoid;
 }
 
 footer .detalhes {


### PR DESCRIPTION
A ideia é evitar esse tipo de quebra de página:
![image](https://github.com/user-attachments/assets/0e947676-0278-40f5-b100-dc1eec8c8918)

Para que a quebra de página seja entre as seções
![image](https://github.com/user-attachments/assets/8be9f878-0921-456c-af33-ac520cb8ecf4)
