### PR TITLE
Correção de erro ao cancelar e excluir cobrança do ASAAS e do Mercado Livre

### DIFF
--- a/application/config/payment_gateways.php
+++ b/application/config/payment_gateways.php
@@ -106,6 +106,7 @@ $config['payment_gateways'] = [
             'DUNNING_REQUESTED' => 'Em processo de recuperação',
             'DUNNING_RECEIVED' => 'Recuperada',
             'AWAITING_RISK_ANALYSIS' => 'Pagamento em análise',
+            'DELETED' => 'Cobrança excluída ou cancelada',
         ],
     ],
 ];

--- a/application/libraries/Gateways/Asaas.php
+++ b/application/libraries/Gateways/Asaas.php
@@ -106,6 +106,12 @@ class Asaas extends BasePaymentGateway
             throw new Exception('Devido à limitação da Asaas, somente é possível atualizar cobranças com boletos!');
         }
 
+        // Verifica se a cobrança já foi deletada
+        if ($result->deleted) {
+            // Atribui o valor DELETED ao status para atualizar o status no banco de dados
+            $result->status = 'DELETED';
+        }
+        
         // Cobrança foi paga ou foi confirmada de forma manual, então damos baixa
         if ($result->status == 'RECEIVED' || $result->status == 'CONFIRMED' || $result->status == 'DUNNING_RECEIVED') {
             // TODO: dar baixa no lançamento caso exista

--- a/application/libraries/Gateways/MercadoPago.php
+++ b/application/libraries/Gateways/MercadoPago.php
@@ -49,6 +49,11 @@ class MercadoPago extends BasePaymentGateway
             throw new \Exception($payment->Error());
         }
 
+        // Se o status for 'cancelled', não podemos cancelar novamente
+        if ($payment->status === 'cancelled') {
+            return $this->atualizarDados($id);
+        }
+
         $payment->status = 'cancelled';
         $payment->update();
         if ($payment->Error()) {


### PR DESCRIPTION
Ao tentar cancelar cobranças de boletos dos gateways de pagamentos ASAAS e Mercado Pago na tela de Cobranças, a coluna status da tabela não atualiza. Este erro acontece por dois motivos, sendo que um dos motivos gera erro ao cancelar cobrança de boleto na API do ASAAS, e o outro ao cancelar na API do Mercado Pago.

API ASAAS: Ao cancelar a cobrança, ela é excluída e depois identificada, como tal, por meio da chave _deleted_ na resposta JSON da API ao recuperar uma única cobrança. Mas a chave _status_ da resposta JSON da API não possui valor que a identifique como excluída ou cancelada, por isso é necessário verificar se a chave _deleted_ contém valor true (verdadeiro), e se conter, atribuir o valor _DELETED_ ao campo status da cobrança no banco de dados. E para associar a descrição do status _DELETED_, contido apenas no banco de dados, é necessário incluir o elemento DELETED na '_transaction_status_' contido no arquivo **./application/config/payment_gateways.php** referente ao gateway ASAAS.

Mercado Pago: Ao cancelar a cobrança, a mesma é cancelada no Mercado Pago, porém não é atualizada no banco de dados porque ao executar o método $payment->update, após atribuir o valor _cancelled_ ao $payment->status, é retornado um erro com a seguinte mensagem: "bad_request: status attribute can't be null". E ao tentar excluir, posteriormente, a mesma mensagem de erro é apresentada e não é possível concluir a exclusão da cobrança no banco de dados.

Gravação do erro gerado ao cancelar:
[Gravação de tela de 2025-06-02 21-44-29.webm](https://github.com/user-attachments/assets/9e010615-d936-4c49-a1d4-d4c52cc315b6)

Gravação após a correção:
[Gravação de tela de 2025-06-02 23-23-49.webm](https://github.com/user-attachments/assets/f7751245-238a-44b2-9462-9cd719f1dbfa)

