### PR TITLE
Permite valor fracionado nos campos de quantidade de produtos e serviços

### DIFF
--- a/application/views/os/editarOs.php
+++ b/application/views/os/editarOs.php
@@ -576,14 +576,92 @@
         }
     }
     var valorBackup = $("#valorTotal").val();
-
-    $("#quantidade").keyup(function () {
-        this.value = this.value.replace(/[^0-9.]/g, '');
+    
+    $("#quantidade").keyup(function() {
+        // Permite números, ponto e vírgula como separador decimal
+        var value = this.value;
+        
+        // Remove caracteres não numéricos exceto ponto e vírgula
+        value = value.replace(/[^0-9.,]/g, '');
+        
+        // Se há vírgula, converte para ponto
+        if (value.indexOf(',') !== -1) {
+            value = value.replace(',', '.');
+        }
+        
+        // Garante que há apenas um ponto decimal
+        var parts = value.split('.');
+        if (parts.length > 2) {
+            value = parts[0] + '.' + parts.slice(1).join('');
+        }
+        
+        this.value = value;
     });
 
-    $("#quantidade_servico").keyup(function () {
-        this.value = this.value.replace(/[^0-9.]/g, '');
+    $("#quantidade").blur(function() {
+        // Garante conversão final quando o campo perde o foco
+        var value = this.value;
+        
+        // Remove caracteres não numéricos exceto ponto e vírgula
+        value = value.replace(/[^0-9.,]/g, '');
+        
+        // Se há vírgula, converte para ponto
+        if (value.indexOf(',') !== -1) {
+            value = value.replace(',', '.');
+        }
+        
+        // Garante que há apenas um ponto decimal
+        var parts = value.split('.');
+        if (parts.length > 2) {
+            value = parts[0] + '.' + parts.slice(1).join('');
+        }
+        
+        this.value = value;
     });
+
+    $("#quantidade_servico").keyup(function() {
+        // Permite números, ponto e vírgula como separador decimal
+        var value = this.value;
+        
+        // Remove caracteres não numéricos exceto ponto e vírgula
+        value = value.replace(/[^0-9.,]/g, '');
+        
+        // Se há vírgula, converte para ponto
+        if (value.indexOf(',') !== -1) {
+            value = value.replace(',', '.');
+        }
+        
+        // Garante que há apenas um ponto decimal
+        var parts = value.split('.');
+        if (parts.length > 2) {
+            value = parts[0] + '.' + parts.slice(1).join('');
+        }
+        
+        this.value = value;
+    });
+
+    $("#quantidade_servico").blur(function() {
+        // Garante conversão final quando o campo perde o foco
+        var value = this.value;
+        
+        // Remove caracteres não numéricos exceto ponto e vírgula
+        value = value.replace(/[^0-9.,]/g, '');
+        
+        // Se há vírgula, converte para ponto
+        if (value.indexOf(',') !== -1) {
+            value = value.replace(',', '.');
+        }
+        
+        // Garante que há apenas um ponto decimal
+        var parts = value.split('.');
+        if (parts.length > 2) {
+            value = parts[0] + '.' + parts.slice(1).join('');
+        }
+        
+        this.value = value;
+    });
+
+
     $('#tipoDesconto').on('change', function () {
         if (Number($("#desconto").val()) >= 0) {
             $('#resultado').val(calcDesconto(Number($("#valorTotal").val()), Number($("#desconto").val()), $("#tipoDesconto").val()));


### PR DESCRIPTION
Atualização nos campos de quantidade na tela de produtos e serviços da Ordem de Serviço.

Antes:
Só era possível inserir números inteiros (ex: 1, 2), impedindo o uso de valores fracionados.

Agora:
É possível informar valores decimais (ex: 1.5, 0.25), permitindo maior precisão no controle de itens e serviços prestados.

Essa melhoria é útil para casos em que produtos ou serviços são utilizados em quantidades parciais, como materiais por metro ou horas de trabalho fracionadas.