### PR TITLE
🛠️ Atualiza campo de desconto na Ordem de Serviço para tratar vírgula como ponto decimal

### DIFF
--- a/application/views/os/editarOs.php
+++ b/application/views/os/editarOs.php
@@ -590,8 +590,17 @@
             $('#resultado').val(validarDesconto(Number($('#resultado').val()), Number($("#valorTotal").val())));
         }
     });
-    $("#desconto").keyup(function () {
+    
+    $("#desconto").keyup(function() {
+        // Primeiro: converte vírgula para ponto
+        var value = this.value;
+        value = value.replace(',', '.');
+        this.value = value;
+        
+        // Depois: aplica a validação existente
         this.value = this.value.replace(/[^0-9.]/g, '');
+        
+        // Lógica existente de validação
         if ($("#valorTotal").val() == null || $("#valorTotal").val() == '') {
             $('#errorAlert').text('Valor não pode ser apagado.').css("display", "inline").fadeOut(5000);
             $('#desconto').val('');
@@ -607,6 +616,13 @@
             $('#desconto').val('');
             $('#resultado').val('');
         }
+    });
+
+    $("#desconto").blur(function() {
+        // Garante conversão final quando o campo perde o foco
+        var value = this.value;
+        value = value.replace(',', '.');
+        this.value = value;
     });
 
     $("#valorTotal").focusout(function () {


### PR DESCRIPTION
Atualiza campo de desconto na Ordem de Serviço para converter automaticamente vírgula (,) em ponto (.) durante a digitação


Ao digitar uma vírgula (,) no campo de desconto, o sistema apagava o ponto (.), o que podia causar erro no valor inserido.
📎 Exemplo do problema:

https://github.com/user-attachments/assets/0c3a0ab1-89d7-462c-9aa0-b6bf0da70bc8




Depois:
Agora, ao digitar uma vírgula, ela é automaticamente convertida para ponto. Isso evita erros e melhora a experiência do usuário.
✅ Exemplo da correção aplicada:


https://github.com/user-attachments/assets/7b5fb721-0a15-474d-823d-0d6fec8e854d






