### PR TITLE
Correção da impressão em vendas

### DIFF
--- a/application/views/vendas/imprimirVenda.php
+++ b/application/views/vendas/imprimirVenda.php
@@ -60,7 +60,7 @@
                             <tbody>
                                 <tr>
                                     <td class="text-center"><?= $result->status ?></td>
-                                    <td class="text-center"><?= date('d/m/Y H:i:s', strtotime($result->dataVenda)) ?></td>
+                                    <td class="text-center"><?= date('d/m/Y', strtotime($result->dataVenda)) ?></td>
                                     <td class="text-center">
                                         <?php if ($result->garantia > 0): ?>
                                             <?= $result->garantia . ' dia(s)' ?>

--- a/application/views/vendas/imprimirVendaOrcamento.php
+++ b/application/views/vendas/imprimirVendaOrcamento.php
@@ -42,7 +42,7 @@
             <section>
                 <div class="title">
                     ORÇAMENTO DA VENDA Nº#<?= str_pad($result->idVendas, 4, 0, STR_PAD_LEFT) ?>
-                    <span class="emissao">Emissão: <?= date('d/m/Y H:i:s') ?></span>
+                    <span class="emissao">Emissão: <?= date('d/m/Y') ?></span>
                 </div>
 
                 <?php if ($result->dataVenda != null): ?>

--- a/application/views/vendas/imprimirVendaTermica.php
+++ b/application/views/vendas/imprimirVendaTermica.php
@@ -44,7 +44,7 @@
                                     <tr>
                                         <td colspan="4" style="width: 100%;"><b>#Venda: </b><span>
                                                 <?php echo $result->idVendas ?></span>
-                                            <span style="padding-inline: 1em">Emissão: <?php echo date('d/m/Y H:i:s'); ?></span>
+                                            <span style="padding-inline: 1em">Emissão: <?php echo date('d/m/Y'); ?></span>
                                             <?php if ($result->faturado) : ?>
                                                 <br>
                                                 <b>Venc. Garantia: </b>


### PR DESCRIPTION
Essa correção retira os dados de hora no imprimir vendas que o banco não salva ao gerar a venda.

