### PR TITLE
Correção Index.php para PHP8.4

### DIFF
--- a/index.php
+++ b/index.php
@@ -105,7 +105,7 @@ switch (ENVIRONMENT) {
     case 'production':
         ini_set('display_errors', 0);
         if (version_compare(PHP_VERSION, '5.3', '>=')) {
-            error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT & ~E_USER_NOTICE & ~E_USER_DEPRECATED);
+            error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_USER_NOTICE & ~E_USER_DEPRECATED);
         } else {
             error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_USER_NOTICE);
         }


### PR DESCRIPTION
Com a alteração para PHP8.4 esse trecho precisa ser corrigido para não ficar gerando erro nos logs.