### PR TITLE
substitui unserialize() por json_decode() em permissões e fila de emails

### DIFF
--- a/application/controllers/Mine.php
+++ b/application/controllers/Mine.php
@@ -981,7 +981,7 @@ class Mine extends CI_Controller
             'message' => $html,
             'status' => 'pending',
             'date' => date('Y-m-d H:i:s'),
-            'headers' => serialize($headers),
+            'headers' => json_encode($headers),
         ];
 
         return $this->email_model->add('email_queue', $email);
@@ -1023,7 +1023,7 @@ class Mine extends CI_Controller
                 'message' => $html,
                 'status' => 'pending',
                 'date' => date('Y-m-d H:i:s'),
-                'headers' => serialize($headers),
+                'headers' => json_encode($headers),
             ];
             $this->email_model->add('email_queue', $email);
         }
@@ -1058,7 +1058,7 @@ class Mine extends CI_Controller
             'message' => $html,
             'status' => 'pending',
             'date' => date('Y-m-d H:i:s'),
-            'headers' => serialize($headers),
+            'headers' => json_encode($headers),
         ];
 
         return $this->email_model->add('email_queue', $email);
@@ -1093,7 +1093,7 @@ class Mine extends CI_Controller
                 'message' => $html,
                 'status' => 'pending',
                 'date' => date('Y-m-d H:i:s'),
-                'headers' => serialize($headers),
+                'headers' => json_encode($headers),
             ];
             $this->email_model->add('email_queue', $email);
         }

--- a/application/controllers/Os.php
+++ b/application/controllers/Os.php
@@ -1135,7 +1135,7 @@ class Os extends MY_Controller
                     'message' => $html,
                     'status' => 'pending',
                     'date' => date('Y-m-d H:i:s'),
-                    'headers' => serialize($headers),
+                    'headers' => json_encode($headers),
                 ];
                 $this->email_model->add('email_queue', $email);
             } else {

--- a/application/controllers/Permissoes.php
+++ b/application/controllers/Permissoes.php
@@ -121,7 +121,7 @@ class Permissoes extends MY_Controller
                 'dCobranca' => $this->input->post('dCobranca'),
                 'vCobranca' => $this->input->post('vCobranca'),
             ];
-            $permissoes = serialize($permissoes);
+            $permissoes = json_encode($permissoes);
 
             $data = [
                 'nome' => $nomePermissao,
@@ -223,7 +223,7 @@ class Permissoes extends MY_Controller
                 'vCobranca' => $this->input->post('vCobranca'),
 
             ];
-            $permissoes = serialize($permissoes);
+            $permissoes = json_encode($permissoes);
 
             $data = [
                 'nome' => $nomePermissao,

--- a/application/controllers/api/v1/OsController.php
+++ b/application/controllers/api/v1/OsController.php
@@ -960,7 +960,7 @@ class OsController extends REST_Controller
                     'message' => $html,
                     'status' => 'pending',
                     'date' => date('Y-m-d H:i:s'),
-                    'headers' => serialize($headers),
+                    'headers' => json_encode($headers),
                 ];
                 $this->email_model->add('email_queue', $email);
             } else {

--- a/application/controllers/api/v1/UsuariosController.php
+++ b/application/controllers/api/v1/UsuariosController.php
@@ -271,12 +271,7 @@ class UsuariosController extends REST_Controller
             // Verificar credenciais do usuário
             if (password_verify($password, $user->senha)) {
                 $this->log_app('Efetuou login no sistema', $user->nome);
-                $permissoes = $this->getInstanceDatabase('permissoes', '*', 'idPermissao = ' . $user->permissoes_id, 1, true);
-                $raw = $permissoes['permissoes'];
-                $permissoes = json_decode($raw, true);
-                if ($permissoes === null && json_last_error() !== JSON_ERROR_NONE) {
-                    $permissoes = unserialize($raw, ['allowed_classes' => false]);
-                }
+                $permissoes = json_decode_legacy($this->getInstanceDatabase('permissoes', '*', 'idPermissao = ' . $user->permissoes_id, 1, true)['permissoes']);
 
                 $token_data = [
                     'uid' => $user->idUsuarios,
@@ -326,12 +321,7 @@ class UsuariosController extends REST_Controller
                     'permissao' => $user->permissoes_id,
                 ];
 
-                $permissoes = $this->getInstanceDatabase('permissoes', '*', 'idPermissao = ' . $user->permissoes_id, 1, true);
-                $raw = $permissoes['permissoes'];
-                $permissoes = json_decode($raw, true);
-                if ($permissoes === null && json_last_error() !== JSON_ERROR_NONE) {
-                    $permissoes = unserialize($raw, ['allowed_classes' => false]);
-                }
+                $permissoes = json_decode_legacy($this->getInstanceDatabase('permissoes', '*', 'idPermissao = ' . $user->permissoes_id, 1, true)['permissoes']);
 
                 $result = [
                     'access_token' => $this->authorization_token->generateToken($token_data),

--- a/application/controllers/api/v1/UsuariosController.php
+++ b/application/controllers/api/v1/UsuariosController.php
@@ -272,7 +272,11 @@ class UsuariosController extends REST_Controller
             if (password_verify($password, $user->senha)) {
                 $this->log_app('Efetuou login no sistema', $user->nome);
                 $permissoes = $this->getInstanceDatabase('permissoes', '*', 'idPermissao = ' . $user->permissoes_id, 1, true);
-                $permissoes = unserialize($permissoes['permissoes']);
+                $raw = $permissoes['permissoes'];
+                $permissoes = json_decode($raw, true);
+                if ($permissoes === null && json_last_error() !== JSON_ERROR_NONE) {
+                    $permissoes = unserialize($raw, ['allowed_classes' => false]);
+                }
 
                 $token_data = [
                     'uid' => $user->idUsuarios,
@@ -323,7 +327,11 @@ class UsuariosController extends REST_Controller
                 ];
 
                 $permissoes = $this->getInstanceDatabase('permissoes', '*', 'idPermissao = ' . $user->permissoes_id, 1, true);
-                $permissoes = unserialize($permissoes['permissoes']);
+                $raw = $permissoes['permissoes'];
+                $permissoes = json_decode($raw, true);
+                if ($permissoes === null && json_last_error() !== JSON_ERROR_NONE) {
+                    $permissoes = unserialize($raw, ['allowed_classes' => false]);
+                }
 
                 $result = [
                     'access_token' => $this->authorization_token->generateToken($token_data),

--- a/application/helpers/general_helper.php
+++ b/application/helpers/general_helper.php
@@ -85,6 +85,18 @@ if (! function_exists('getAmount')) {
     }
 }
 
+if (! function_exists('json_decode_legacy')) {
+    function json_decode_legacy(string $raw): mixed
+    {
+        $decoded = json_decode($raw, true);
+        if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
+            $decoded = unserialize($raw, ['allowed_classes' => false]);
+        }
+
+        return $decoded;
+    }
+}
+
 if (! function_exists('printSafeHtml')) {
     function printSafeHtml(string $html): string
     {

--- a/application/libraries/Format.php
+++ b/application/libraries/Format.php
@@ -471,7 +471,7 @@ class Format
      */
     protected function _from_serialize($data)
     {
-        return unserialize(trim($data));
+        return unserialize(trim($data), ['allowed_classes' => false]);
     }
 
     /**

--- a/application/libraries/Gateways/Asaas.php
+++ b/application/libraries/Gateways/Asaas.php
@@ -87,7 +87,7 @@ class Asaas extends BasePaymentGateway
                 'message' => $html,
                 'status' => 'pending',
                 'date' => date('Y-m-d H:i:s'),
-                'headers' => serialize($headers),
+                'headers' => json_encode($headers),
             ];
             $this->ci->email_model->add('email_queue', $email);
         }

--- a/application/libraries/Gateways/GerencianetSdk.php
+++ b/application/libraries/Gateways/GerencianetSdk.php
@@ -87,7 +87,7 @@ class GerencianetSdk extends BasePaymentGateway
                 'message' => $html,
                 'status' => 'pending',
                 'date' => date('Y-m-d H:i:s'),
-                'headers' => serialize($headers),
+                'headers' => json_encode($headers),
             ];
             $this->ci->email_model->add('email_queue', $email);
         }

--- a/application/libraries/Gateways/MercadoPago.php
+++ b/application/libraries/Gateways/MercadoPago.php
@@ -84,7 +84,7 @@ class MercadoPago extends BasePaymentGateway
                 'message' => $html,
                 'status' => 'pending',
                 'date' => date('Y-m-d H:i:s'),
-                'headers' => serialize($headers),
+                'headers' => json_encode($headers),
             ];
             $this->ci->email_model->add('email_queue', $email);
         }

--- a/application/libraries/MY_Email.php
+++ b/application/libraries/MY_Email.php
@@ -142,12 +142,7 @@ class MY_Email extends CI_Email
             $cc = ! empty($email->cc) ? explode(', ', $email->cc) : [];
             $bcc = ! empty($email->bcc) ? explode(', ', $email->bcc) : [];
 
-            $raw = $email->headers;
-            $decoded = json_decode($raw, true);
-            if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
-                $decoded = unserialize($raw, ['allowed_classes' => false]);
-            }
-            $this->_headers = $decoded;
+            $this->_headers = json_decode_legacy($email->headers);
 
             $this->to($recipients);
             $this->cc($cc);

--- a/application/libraries/MY_Email.php
+++ b/application/libraries/MY_Email.php
@@ -96,7 +96,7 @@ class MY_Email extends CI_Email
             'cc' => $cc,
             'bcc' => $bcc,
             'message' => $this->_body,
-            'headers' => serialize($this->_headers),
+            'headers' => json_encode($this->_headers),
             'status' => 'pending',
             'date' => $date,
         ];
@@ -142,7 +142,12 @@ class MY_Email extends CI_Email
             $cc = ! empty($email->cc) ? explode(', ', $email->cc) : [];
             $bcc = ! empty($email->bcc) ? explode(', ', $email->bcc) : [];
 
-            $this->_headers = unserialize($email->headers);
+            $raw = $email->headers;
+            $decoded = json_decode($raw, true);
+            if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
+                $decoded = unserialize($raw, ['allowed_classes' => false]);
+            }
+            $this->_headers = $decoded;
 
             $this->to($recipients);
             $this->cc($cc);

--- a/application/libraries/Permission.php
+++ b/application/libraries/Permission.php
@@ -70,11 +70,7 @@ class Permission
 
             if (count($array) > 0) {
                 $raw = $array[$this->select];
-                $decoded = json_decode($raw, true);
-                if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
-                    $decoded = unserialize($raw, ['allowed_classes' => false]);
-                }
-                $array = $decoded;
+                $array = json_decode_legacy($raw);
                 $this->permissions = [$array];
 
                 return true;

--- a/application/libraries/Permission.php
+++ b/application/libraries/Permission.php
@@ -69,8 +69,12 @@ class Permission
             $array = $this->CI->db->get($this->table)->row_array();
 
             if (count($array) > 0) {
-                $array = unserialize($array[$this->select]);
-                //Atribui as permissoes ao atributo permissions
+                $raw = $array[$this->select];
+                $decoded = json_decode($raw, true);
+                if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
+                    $decoded = unserialize($raw, ['allowed_classes' => false]);
+                }
+                $array = $decoded;
                 $this->permissions = [$array];
 
                 return true;

--- a/application/views/permissoes/editarPermissao.php
+++ b/application/views/permissoes/editarPermissao.php
@@ -81,13 +81,7 @@
 
 </style>
 
-<?php
-$raw = $result->permissoes;
-$permissoes = json_decode($raw, true);
-if ($permissoes === null && json_last_error() !== JSON_ERROR_NONE) {
-    $permissoes = unserialize($raw, ['allowed_classes' => false]);
-}
-?>
+<?php $permissoes = json_decode_legacy($result->permissoes); ?>
 <div class="span12" style="margin-left: 0">
     <form action="<?php echo base_url();?>index.php/permissoes/editar" id="formPermissao" method="post">
         <div class="span12" style="margin-left: 0">

--- a/application/views/permissoes/editarPermissao.php
+++ b/application/views/permissoes/editarPermissao.php
@@ -81,7 +81,13 @@
 
 </style>
 
-<?php $permissoes = unserialize($result->permissoes);?>
+<?php
+$raw = $result->permissoes;
+$permissoes = json_decode($raw, true);
+if ($permissoes === null && json_last_error() !== JSON_ERROR_NONE) {
+    $permissoes = unserialize($raw, ['allowed_classes' => false]);
+}
+?>
 <div class="span12" style="margin-left: 0">
     <form action="<?php echo base_url();?>index.php/permissoes/editar" id="formPermissao" method="post">
         <div class="span12" style="margin-left: 0">


### PR DESCRIPTION
 fix(security): substitui unserialize() por json_encode/json_decode em todos os pontos críticos

  - Permissões gravadas e lidas como JSON (Permissoes.php, Permission.php, UsuariosController, editarPermissao)
  - Headers da fila de emails gravados e lidos como JSON (MY_Email, Os, Mine, OsController, Gateways)
  - Fallback para dados legados no banco usando unserialize com allowed_classes => false
  - Format.php: unserialize restrito com allowed_classes => false para prevenir object injection via API