### PR TITLE
fix: corrige SQL injection em Cobrancas_model (getByOs e getByVendas)

### DIFF
--- a/application/models/Cobrancas_model.php
+++ b/application/models/Cobrancas_model.php
@@ -40,12 +40,26 @@ class Cobrancas_model extends CI_Model
 
     public function getByOs($id)
     {
-        return $this->db->query("SELECT DISTINCT `cobrancas`.*,`clientes`.*,`os`.* FROM `cobrancas`,`clientes`,`os` WHERE `charge_id` = $id AND `os`.`idOs` = `cobrancas`.`os_id`")->row();
+        $this->db->select('cobrancas.*, clientes.*, os.*');
+        $this->db->distinct();
+        $this->db->from('cobrancas');
+        $this->db->join('os', 'os.idOs = cobrancas.os_id');
+        $this->db->join('clientes', 'clientes.idClientes = cobrancas.clientes_id', 'left');
+        $this->db->where('cobrancas.charge_id', $id);
+
+        return $this->db->get()->row();
     }
 
     public function getByVendas($id)
     {
-        return $this->db->query("SELECT DISTINCT `cobrancas`.*,`clientes`.*,`vendas`.* FROM `cobrancas`,`clientes`,`vendas` WHERE `charge_id` = $id AND `vendas`.`idVendas` = `cobrancas`.`vendas_id`")->row();
+        $this->db->select('cobrancas.*, clientes.*, vendas.*');
+        $this->db->distinct();
+        $this->db->from('cobrancas');
+        $this->db->join('vendas', 'vendas.idVendas = cobrancas.vendas_id');
+        $this->db->join('clientes', 'clientes.idClientes = cobrancas.clientes_id', 'left');
+        $this->db->where('cobrancas.charge_id', $id);
+
+        return $this->db->get()->row();
     }
 
     public function add($table, $data, $returnId = false)


### PR DESCRIPTION
Os métodos getByOs() e getByVendas() construíam queries com interpolação direta da variável $id na string SQL, sem qualquer sanitização ou binding de parâmetros. Isso permitia que um valor controlado pelo usuário fosse executado como SQL arbitrário no banco de dados.

Substituídas as raw queries pelo query builder do CodeIgniter, que vincula os valores como parâmetros e escapa automaticamente a entrada. Os implicit joins por vírgula no FROM também foram convertidos para JOINs explícitos, mantendo o comportamento original mas tornando as relações entre tabelas claras. O join com clientes foi definido como LEFT JOIN para preservar compatibilidade com cobranças sem cliente associado.