### PR TITLE
fix: substitui md5(time()) por random_bytes() na geração do captcha

### DIFF
--- a/application/controllers/Mine.php
+++ b/application/controllers/Mine.php
@@ -1106,7 +1106,7 @@ class Mine extends CI_Controller
         $arrFont = ['font-ZXX_Noise.otf', 'font-karabine.ttf', 'font-capture.ttf', 'font-captcha.ttf'];
         shuffle($arrFont);
 
-        $codigoCaptcha = substr(md5(time()), 0, 7);
+        $codigoCaptcha = substr(bin2hex(random_bytes(4)), 0, 7);
         $img = imagecreatefromjpeg('./assets/img/captcha_bg.jpg');
         $corCaptcha = imagecolorallocate($img, 255, 0, 0);
         $font = './assets/font-awesome/' . $arrFont[0];


### PR DESCRIPTION
O código anterior usava md5(time()) para gerar o código do captcha, tornando-o 
previsível para qualquer atacante que conhecesse o horário aproximado da requisição.

Substituído por bin2hex(random_bytes(4)), que usa o CSPRNG do PHP e garante 
entropia criptograficamente segura.
