### PR TITLE
Correção DataTables para exibir quantidade de registros por página configurado no sistema.

### DIFF
--- a/application/views/tema/rodape.php
+++ b/application/views/tema/rodape.php
@@ -14,6 +14,7 @@
         var dataTableEnabled = '<?= $configuration['control_datatable'] ?>';
         if(dataTableEnabled == '1') {
             $('#tabela').dataTable( {
+                "pageLength": <?= $configuration['per_page'] ?>,
                 "ordering": false,
                 "info": false,
                 "language": {


### PR DESCRIPTION
Proponho a correção apontada na issue #2788 para que o DataTables inicialize exibindo a quantidade de registros por página configurado na tela "Configurações do Sistema".

Ao exibir cadastros que contenham elementos HTML table com atributo id="tabela", a quantidade de registros por página é inicializada exibindo apenas 10 registros por página.

Para reproduzir o erro, modifique a quantidade de registros exibidos por página para 20 registros, ou mais, e abra o cadastro de clientes para verificar se a quantidade de registros exibidos é o mesmo que a quantidade configurada.

Docs Ref.: https://datatables.net/reference/option/pageLength