### PR TITLE
docs: adiciona política de segurança (SECURITY.md) e template de Pull Request

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,56 @@
+<!--
+Obrigado por contribuir com o Map-OS!
+Preencha as seções abaixo e remova as que não se aplicarem ao seu PR.
+
+Falhas de segurança NÃO devem ser enviadas por Pull Request público.
+Reporte em privado para contato@mapos.com.br (veja SECURITY.md).
+-->
+
+## Descrição
+
+<!-- O que este PR faz e por quê. Se corrige um bug, descreva o comportamento anterior e o novo. -->
+
+## Issue relacionada
+
+<!-- Ex.: Closes #123 / Relacionado a #123. Deixe em branco se não houver. -->
+
+## Tipo de mudança
+
+<!-- Marque com "x" o que se aplica. -->
+
+- [ ] Correção de bug (`fix`)
+- [ ] Nova funcionalidade (`feat`)
+- [ ] Documentação (`docs`)
+- [ ] Refatoração sem mudança de comportamento (`refactor`)
+- [ ] Dependências / manutenção (`chore`)
+
+## Como testar
+
+<!--
+Passos para o revisor reproduzir e validar a mudança. Exemplo:
+1. Acesse Vendas > Nova venda
+2. Aplique um desconto em percentual
+3. Confirme que o total exibido bate com o valor salvo
+-->
+
+## Capturas de tela
+
+<!-- Obrigatório para mudanças visuais. Sempre que possível, mostre "antes" e "depois". -->
+
+## Checklist
+
+- [ ] O PR resolve **um** assunto (correções e refatorações não estão misturadas).
+- [ ] O código foi formatado com `composer format`.
+- [ ] Testei manualmente o fluxo afetado.
+- [ ] Não há `.env`, credenciais, dumps de banco ou arquivos de IDE no diff.
+- [ ] A pasta `application/vendor/` não foi commitada.
+- [ ] Entrada do usuário é validada e a saída é escapada nas views.
+- [ ] Consultas ao banco usam Query Builder ou *query bindings* (sem concatenação de SQL).
+
+## Banco de dados
+
+<!-- Remova esta seção se o PR não altera o schema. -->
+
+- [ ] A mudança de schema foi feita por **migration** (não editando o `banco.sql`).
+- [ ] A migration implementa `up()` e `down()`.
+- [ ] Testei em uma instalação nova **e** na atualização de uma base existente.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,83 @@
+# Política de Segurança
+
+O Map-OS é usado por empresas para gerenciar ordens de serviço, dados de clientes e informações financeiras. Levamos relatos de segurança a sério e agradecemos quem dedica tempo a encontrar e reportar falhas de forma responsável.
+
+## Versões suportadas
+
+Correções de segurança são publicadas apenas na versão mais recente, a partir da branch `master`. O projeto não mantém branches de suporte para versões antigas.
+
+| Versão | Suportada |
+| --- | --- |
+| 4.54.x (última release) | ✅ |
+| Versões anteriores | ❌ |
+
+Se você está em uma versão antiga, a orientação é atualizar seguindo as instruções de [Atualização](README.md#atualização) do README.
+
+## Como reportar uma vulnerabilidade
+
+**Não abra uma issue pública, Discussion ou mensagem na comunidade do WhatsApp descrevendo a falha.** Um relato público expõe todas as instalações do Map-OS antes que exista correção disponível.
+
+Envie o relato em caráter privado para:
+
+**contato@mapos.com.br**
+
+### O que incluir no relato
+
+Quanto mais completo o relato, mais rápida a correção:
+
+- **Tipo da falha** — por exemplo SQL injection, XSS, IDOR, falha de autenticação/autorização, upload arbitrário de arquivo.
+- **Localização** — arquivo, rota ou tela afetada (ex.: `application/controllers/Os.php`, rota `/os/editar/1`).
+- **Passos para reproduzir** — sequência exata, incluindo requisição HTTP ou payload quando aplicável.
+- **Impacto** — o que um atacante consegue fazer explorando a falha, e qual nível de acesso é necessário (anônimo, usuário autenticado comum, administrador).
+- **Versão e ambiente** — versão do Map-OS, versão do PHP e forma de instalação (manual, Docker ou instalador automatizado).
+- **Sugestão de correção**, se você tiver uma.
+
+### O que acontece depois
+
+1. O relato é confirmado e avaliado pela manutenção do projeto.
+2. Sendo confirmada a falha, uma correção é desenvolvida e publicada em uma nova release.
+3. O relato é divulgado publicamente **após** a correção estar disponível, para que os usuários possam atualizar antes que os detalhes sejam conhecidos.
+
+Os prazos dependem da gravidade da falha e da disponibilidade da manutenção — este é um projeto open source. Se você não obtiver retorno, sinta-se à vontade para enviar uma cobrança pelo mesmo e-mail.
+
+### Créditos
+
+Quem reporta uma falha é creditado no [CHANGELOG](CHANGELOG.md) junto com a correção, como já acontece com as demais contribuições. Se você preferir não ser creditado, avise no relato.
+
+## Escopo
+
+São considerados relatos válidos falhas que afetem o código do Map-OS, como:
+
+- injeção de SQL, XSS, CSRF ou injeção de comandos;
+- falhas de autenticação ou de controle de acesso (incluindo IDOR e escalonamento de privilégios);
+- exposição de dados sensíveis de clientes, financeiros ou de credenciais;
+- upload ou sobrescrita arbitrária de arquivos;
+- falhas nos gateways de pagamento integrados ao sistema.
+
+Normalmente **não** são considerados vulnerabilidades do projeto:
+
+- problemas causados por instalação ou configuração incorreta do servidor (permissões de arquivo, `WHOOPS_ERROR_PAGE_ENABLED` habilitado em produção, banco exposto na internet);
+- falhas que exigem que o atacante já tenha acesso de administrador ao sistema;
+- self-XSS, ou seja, que dependem de a própria vítima colar o payload;
+- ausência de cabeçalhos de segurança sem demonstração de impacto real;
+- resultados brutos de scanners automatizados, sem prova de exploração;
+- vulnerabilidades em dependências de terceiros — nesses casos, reporte ao projeto de origem e, se quiser, abra uma issue aqui apenas solicitando a atualização da dependência.
+
+## Recomendações para quem opera o Map-OS
+
+Boa parte dos incidentes vem de configuração, não de falha no código. Em produção:
+
+- Mantenha o sistema sempre na **última versão** publicada.
+- Instale as dependências com `composer install --no-dev`.
+- Mantenha `WHOOPS_ERROR_PAGE_ENABLED` **desabilitado**, para que erros detalhados não sejam exibidos ao usuário final.
+- Proteja o arquivo `application/.env`, que contém as credenciais do sistema, e nunca o versione.
+- Sirva a aplicação exclusivamente por **HTTPS**.
+- Não exponha o banco de dados diretamente na internet.
+- Faça backups regulares (Configurações > Backup) e teste a restauração.
+- Revise periodicamente os usuários e as permissões cadastradas.
+
+## Contato
+
+**contato@mapos.com.br**
+
+Obrigado por ajudar a manter o Map-OS seguro.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ Correções de segurança são publicadas apenas na versão mais recente, a part
 
 | Versão | Suportada |
 | --- | --- |
-| 4.54.x (última release) | ✅ |
+| Última release | ✅ |
 | Versões anteriores | ❌ |
 
 Se você está em uma versão antiga, a orientação é atualizar seguindo as instruções de [Atualização](README.md#atualização) do README.


### PR DESCRIPTION
## Descrição

O repositório não possui `SECURITY.md` nem template de Pull Request. Este PR adiciona os dois — preenchido, abaixo, no formato do próprio template proposto.

### `SECURITY.md`

O Map-OS lida com dados de clientes e informações financeiras, e o histórico recente mostra um fluxo constante de correções de segurança vindas da comunidade (#2780, #2783, #2784, #2809, além do XSS/RBAC da 4.53.1). Hoje não há nenhum lugar indicando **onde reportar uma falha em privado** — o caminho natural para quem encontra algo acaba sendo abrir uma issue pública, o que expõe todas as instalações antes de existir correção.

O arquivo documenta:

- **Canal privado de reporte** — contato@mapos.com.br, com aviso explícito para não abrir issue pública, Discussion ou mensagem no WhatsApp.
- **Versões suportadas** — apenas a última release, refletindo o fato de o projeto ter só a branch `master` e cortar releases a partir dela.
- **O que incluir no relato** — tipo, localização, reprodução, impacto, nível de acesso necessário, versão e ambiente.
- **Escopo** — o que é falha do projeto e o que normalmente não é (erro de configuração do servidor, falhas que exigem acesso de administrador, self-XSS, saída bruta de scanner, CVE em dependência de terceiros).
- **Créditos** — quem reporta é creditado no CHANGELOG, como já é praticado com as demais contribuições.
- **Hardening em produção** — `composer install --no-dev`, `WHOOPS_ERROR_PAGE_ENABLED` desabilitado, proteção do `application/.env`, HTTPS, backups.

### `.github/PULL_REQUEST_TEMPLATE.md`

Template com descrição, issue relacionada, tipo de mudança (alinhado aos prefixos de Conventional Commits já usados no histórico), passos de teste, capturas de tela e checklist. Inclui uma seção condicional para alterações de schema, lembrando de usar migration com `up()`/`down()` em vez de editar o `banco.sql`, e de testar tanto instalação nova quanto atualização.

## Issue relacionada

Nenhuma.

## Tipo de mudança

- [x] Documentação (`docs`)

## Como testar

1. Confirme que o `SECURITY.md` aparece na aba **Security > Policy** do repositório.
2. Abra um Pull Request de teste e confirme que o corpo é pré-preenchido com o template.

## Checklist

- [x] O PR resolve um assunto (apenas documentação de processo).
- [x] Nenhum código de aplicação foi alterado.
- [x] Não há `.env`, credenciais ou arquivos de IDE no diff.

## Observações para a manutenção

- **Os prazos de resposta ficaram propositalmente sem números.** Não me pareceu certo comprometer a manutenção com um SLA — o texto diz apenas que depende da gravidade e da disponibilidade. Se vocês quiserem fixar um prazo, é só ajustar.
- **A tabela de versões suportadas** reflete o que observei na prática (só `master`, releases cortadas dela). Se a intenção for dar suporte a alguma versão anterior, ajusto.
- **O e-mail usado foi o `contato@mapos.com.br`**, que já é o contato público do README. Se existir um endereço dedicado a segurança, troco.
- Vale considerar habilitar o **Private Vulnerability Reporting** do GitHub (Settings > Code security), que dá um canal nativo e permite publicar advisories. Se habilitarem, adiciono a referência no `SECURITY.md`.
- Este PR é **independente** do #2812 (guia de contribuição) e pode ser mergeado em qualquer ordem. Depois que ambos entrarem, posso abrir um PR pequeno cruzando os links entre `CONTRIBUTING.md` e `SECURITY.md`.