### PR TITLE
fix: evita reexecução de migrations em instalação nova

### DIFF
--- a/banco.sql
+++ b/banco.sql
@@ -657,7 +657,14 @@ INSERT IGNORE INTO `permissoes` (`idPermissao`, `nome`, `permissoes`, `situacao`
 INSERT IGNORE INTO `usuarios` (`idUsuarios`, `nome`, `rg`, `cpf`, `cep`, `rua`, `numero`, `bairro`, `cidade`, `estado`, `email`, `senha`, `telefone`, `celular`, `situacao`, `dataCadastro`, `permissoes_id`,`dataExpiracao`) VALUES
 (1, 'admin_name', 'MG-25.502.560', '600.021.520-87', '70005-115', 'Rua Acima', '12', 'Alvorada', 'Teste', 'MG', 'admin_email', 'admin_password', '000000-0000', '', 1, 'admin_created_at', 1, '3000-01-01');
 
-INSERT IGNORE INTO `migrations`(`version`) VALUES ('20210125173741');
+-- Este arquivo já contém o schema completo, incluindo o resultado de todas as
+-- migrations existentes. Por isso a versão registrada abaixo deve ser sempre a
+-- da ÚLTIMA migration em application/database/migrations/, caso contrário as
+-- migrations já contempladas aqui seriam executadas novamente em uma instalação
+-- nova, falhando com "Duplicate column name" / "Duplicate entry".
+-- Ao adicionar uma nova migration, replique a alteração neste arquivo e
+-- atualize a versão abaixo.
+INSERT IGNORE INTO `migrations`(`version`) VALUES ('20240503170400');
 
 SET SQL_MODE=@OLD_SQL_MODE;
 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;

--- a/banco.sql
+++ b/banco.sql
@@ -657,13 +657,6 @@ INSERT IGNORE INTO `permissoes` (`idPermissao`, `nome`, `permissoes`, `situacao`
 INSERT IGNORE INTO `usuarios` (`idUsuarios`, `nome`, `rg`, `cpf`, `cep`, `rua`, `numero`, `bairro`, `cidade`, `estado`, `email`, `senha`, `telefone`, `celular`, `situacao`, `dataCadastro`, `permissoes_id`,`dataExpiracao`) VALUES
 (1, 'admin_name', 'MG-25.502.560', '600.021.520-87', '70005-115', 'Rua Acima', '12', 'Alvorada', 'Teste', 'MG', 'admin_email', 'admin_password', '000000-0000', '', 1, 'admin_created_at', 1, '3000-01-01');
 
--- Este arquivo já contém o schema completo, incluindo o resultado de todas as
--- migrations existentes. Por isso a versão registrada abaixo deve ser sempre a
--- da ÚLTIMA migration em application/database/migrations/, caso contrário as
--- migrations já contempladas aqui seriam executadas novamente em uma instalação
--- nova, falhando com "Duplicate column name" / "Duplicate entry".
--- Ao adicionar uma nova migration, replique a alteração neste arquivo e
--- atualize a versão abaixo.
 INSERT IGNORE INTO `migrations`(`version`) VALUES ('20240503170400');
 
 SET SQL_MODE=@OLD_SQL_MODE;


### PR DESCRIPTION
## Descrição

O `banco.sql` já contém o schema resultante de **todas** as migrations, mas registra na tabela `migrations` a versão `20210125173741` (linha 660). Existem **9 migrations posteriores** a essa versão, então numa instalação nova elas são executadas de novo na primeira vez que se usa *Configurações > Sistema > Atualizar Banco de Dados* (`application/controllers/Mapos.php:505`) ou `php index.php tools migrate` — justamente o passo que o README orienta a fazer.

Todas falham, porque as colunas e registros já existem.

## Reprodução

MySQL 8.0 limpo, importando o `banco.sql` atual e executando as migrations pendentes:

```
######## 20220216173741_upload_image_user
ERROR 1060 (42S21): Duplicate column name 'url_image_user'
######## 20220307173741_add_password_client
ERROR 1060 (42S21): Duplicate column name 'senha'
######## 20220313023104_controle_editar_vendas
ERROR 1062 (23000): Duplicate entry '13' for key 'configuracoes.PRIMARY'
######## 20221112173741_add_tipo_desconto_os_vendas
ERROR 1060 (42S21): Duplicate column name 'tipo_desconto'
######## 20221119210810_add_asaas_id_clientes
ERROR 1060 (42S21): Duplicate column name 'asaas_id'
```

## Por que isso passa despercebido

Depois da instalação, `install/do_install.php:104` grava `APP_ENVIRONMENT=production`, e `application/config/database.php:16` define `db_debug` como `(ENVIRONMENT !== 'production')`. Com `db_debug` falso, o driver apenas retorna `false` e a execução continua.

O agravante está no próprio CodeIgniter — `system/libraries/Migration.php`:

```php
$migration[0] = new $migration[0];
call_user_func($migration);        // retorno descartado
$current_version = $number;
$this->_update_version($current_version);   // grava a versão de qualquer jeito
```

A versão é gravada independentemente de o `up()` ter funcionado. Ou seja:

- **em produção** (padrão): falha silenciosa, a versão avança e os erros só aparecem no log — nada quebra visivelmente, porque o schema já estava correto;
- **em desenvolvimento** (`db_debug` verdadeiro): a operação aborta com página de erro de banco, atingindo justamente quem está contribuindo com o projeto;
- **no geral**: normaliza a falha silenciosa de migration. Se um dia uma migration legítima falhar, ela será registrada como aplicada e o banco diverge sem aviso.

## Correção

Atualiza a versão registrada no `banco.sql` para a da última migration existente (`20240503170400`) e adiciona um comentário no arquivo lembrando de mantê-la em dia ao criar novas migrations.

## Validação

Comparei, no MySQL 8.0, o schema de uma **instalação nova** com o de uma **instalação atualizada** (importando o `banco.sql` anterior às 9 migrations e aplicando-as em sequência):

- as tabelas são idênticas nos dois caminhos;
- após a correção, uma instalação nova registra `20240503170400` e **nenhuma** migration fica pendente;
- o schema gerado pelo `banco.sql` corrigido é **byte a byte igual** ao anterior — a única mudança é a versão registrada.

O `banco.sql` só é lido por `install/do_install.php`, então **instalações existentes não são afetadas**.

## Divergência adicional encontrada (não corrigida aqui)

A comparação revelou duas colunas cujo tipo difere entre instalação nova e instalação atualizada:

| Coluna | Instalação nova (`banco.sql`) | Via migrations |
| --- | --- | --- |
| `cobrancas.total` | `varchar(15)` | `decimal(10,2)` |
| `vendas.garantia` | `int` | `varchar(45)` |

Nenhuma das duas quebra o comportamento atual: `cobrancas.total` guarda centavos via `getMoneyAsCents()` e as views dividem por 100 (`views/cobrancas/cobrancas.php:58`), e `vendas.garantia` recebe um número de dias de um `input type="number"` (`views/vendas/adicionarVenda.php:63`).

Deixei fora deste PR de propósito: normalizar isso exige decidir qual tipo é o correto para cada coluna — e, no caso de `vendas.garantia`, o `int` do `banco.sql` me parece mais adequado que o `varchar(45)` da migration. Sendo do interesse da manutenção, abro um PR separado com uma migration de normalização mais o ajuste no `banco.sql`.