### PR TITLE
Correção auditoria area do cliente

### DIFF
--- a/application/controllers/Mine.php
+++ b/application/controllers/Mine.php
@@ -206,9 +206,6 @@ class Mine extends CI_Controller
                         'isCliente' => true
                     ];
                     $this->session->set_userdata($session_mine_data);
-                    log_info($_SERVER['REMOTE_ADDR'] . ' Efetuou login no sistema');
-
-                    // Registrar login na auditoria
                     $this->load->model('Audit_model');
                     $log_data = [
                         'usuario' => $cliente->nomeCliente,


### PR DESCRIPTION
Correção da auditoria que salva 2 vezes devido ao erro no nome_admin que no caso cliente apenas nome. 